### PR TITLE
Review documentation procedures

### DIFF
--- a/common_issues.md
+++ b/common_issues.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-title: Common issues
 nav_order: 6
 ---
 

--- a/configuring_project.md
+++ b/configuring_project.md
@@ -1,16 +1,13 @@
 ---
 layout: page
-title: Configuring SlimeVR firmware project
 parent: Updating SlimeVR Tracker firmware
 nav_order: 1
 ---
 
-# Configuring the SlimeVR Firmware Files
+# Configuring the firmware project
 {:.no_toc}
 
-Before uploading your firmware you will need to edit the project in order to match your specific configuration.
-
-These two files are the platformIo ini file, which handles your WiFi board and the defines.h file, which handles your IMU (rotation, type and how it is connected to the WiFi board).
+In order to build SlimeVR firmware and upload it to your tracker, you need to configure the project to match your specific hardware configuration. To do this, you need to modify two files: `platformio.ini` and `defines.h`.
 
 ## Table of contents
 {:.no_toc}
@@ -18,11 +15,11 @@ These two files are the platformIo ini file, which handles your WiFi board and t
 * TOC
 {:toc}
 
-## Configuring PlatformIO project
+## Configuring platformio.ini
 
-To use the PlatformIO project with your specific configuration, you need to make changes in the `platformio.ini` file.
+The `platformio.ini` file specifies the information about your WiFi board.
 
-This file can be found in the root directory of the project as follows:
+This file can be found in the root directory of the project:
 
 ![platformio.ini file location](https://i.imgur.com/CsBcxYL.png)
 
@@ -72,9 +69,9 @@ build_flags =
 
 ## Configuring defines.h
 
-To use this project with your specific configuration, you need to make changes in the `defines.h` file.
+The `defines.h` file specifies the information about your IMU.
 
-This file can be found in the src directory of the project as follows:
+This file can be found in the `src` directory of the project:
 
 ![defines.h file location](https://i.imgur.com/KlAq8tT.png)
 
@@ -121,7 +118,7 @@ Default would be `BOARD_SLIMEVR`. You can change to `BOARD_NODEMCU` if you are u
 
 #### Adjust board rotation
 
-Set `IMU_ROTATION` to value that corespons to how the sensor board is placed inside the case of your tracker.
+Set `IMU_ROTATION` to value that corresponds to how the sensor board is placed inside the case of your tracker.
 
 ```c
 #define IMU_ROTATION PI / 2.0

--- a/configuring_project.md
+++ b/configuring_project.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-parent: Updating SlimeVR Tracker firmware
+parent: Updating the tracker firmware
 nav_order: 1
 ---
 

--- a/configuring_project.md
+++ b/configuring_project.md
@@ -17,7 +17,7 @@ In order to build SlimeVR firmware and upload it to your tracker, you need to co
 
 ## Configuring platformio.ini
 
-The `platformio.ini` file specifies the information about your WiFi board.
+The `platformio.ini` file specifies the information about your MCU.
 
 This file can be found in the root directory of the project:
 
@@ -69,7 +69,7 @@ build_flags =
 
 ## Configuring defines.h
 
-The `defines.h` file specifies the information about your IMU.
+The `defines.h` file specifies the information about your IMU and MCU.
 
 This file can be found in the `src` directory of the project:
 
@@ -81,7 +81,7 @@ The contents of `defines.h` file should look as follows:
 
 ### Select your hardware settings
 
-First you need to change these lines which would select your IMU model and board.
+First you need to change these lines which would select your IMU model and MCU.
 
 ```c
 #define IMU IMU_BNO085

--- a/faq_owo.md
+++ b/faq_owo.md
@@ -82,9 +82,9 @@ To learn how to set up tracker roles, refer to [SlimeVR setup guide](slimevr-set
 
 ​Check that the IP is correct.
 
-​**You can input 255.255.255.255 as IP to owoTrack android app**
+​**You can input 255.255.255.255 as IP to owoTrack Android app**
 
-To check your IP address, you can open the Command Prompt (cmd.exe) and execute `ipconfig` command and get your PC IPv4 address field - for example 192.168.1.2 and put it in Owo app.
+To check your IP address, you can open the Powershell window or Command Prompt window (cmd.exe) and execute `ipconfig` command and get your PC IPv4 address field - for example 192.168.1.2 and put it in owoTrack app.
 
 ### I can't find iOS version in App Store
 

--- a/faq_owo.md
+++ b/faq_owo.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-title: owoTrack app
 nav_order: 5
 ---
 

--- a/index.md
+++ b/index.md
@@ -59,7 +59,7 @@ It is possible to use phone in place of trackers, please check the [owoTrack mob
 Regardless of the path you choose, you will still need to go through these steps for configuration:
 
 1. Prepare your firmware using [this guide](upload_firmware_guide.md) (pay close attention to step eight).
-1. Setup SlimeVR Server using [this guide](slimevr-setup.md).
+1. Get started with SlimeVR Server and trackers using [this guide](slimevr-setup.md).
 1. To calibrate body values, refer to [Skeleton auto-configuration](skeleton_auto_config.md).
 
 If you have any problems, feel free to reach out on the [SlimeVR discord](https://discord.gg/SlimeVR).

--- a/skeleton_auto_config.md
+++ b/skeleton_auto_config.md
@@ -17,7 +17,7 @@ Before using skeleton auto-configuration, you must "reset" your body proportion 
 **VERY IMPORTANT:** During the recording, you **must** keep your heels in the same position, otherwise the values will be invalid.
 
 <div class="video-container">
-<iframe width="100%" height="auto" src="https://www.youtube.com/embed/IB7X0cS-kt0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="100%" height="auto" src="https://www.youtube.com/embed/z_HhxXvwkk8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 To use skeleton auto-configuration, follow these steps:

--- a/skeleton_auto_config.md
+++ b/skeleton_auto_config.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-title: Skeleton auto-configuration
 nav_order: 4
 ---
 

--- a/slimevr-setup.md
+++ b/slimevr-setup.md
@@ -24,7 +24,7 @@ This guide should help you set up SlimeVR trackers and software.
 
 Each tracker should blink a LED briefly on startup, and then blink every 10-15 seconds once when the tracker is on. Any other lights (for example, always on, blinking multiple times, etc) mean something is wrong.
 
-If a tracker don't start up, try charging it. Connect the tracker via USB port to your PC or any USB charger. Red LED light should light up to indicate that it's charging. Green LED light means it's fully charging. Try turning the tracker on during charging to see if it works.
+If a tracker doesn't start up, try charging it. Connect the tracker via USB port to your PC or any USB charger. Red LED light should light up to indicate that it's charging. Green LED light means it's fully charged. Try turning the tracker on during charging to see if it works.
 
 ## Before you start
 

--- a/slimevr-setup.md
+++ b/slimevr-setup.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-title: SlimeVR server setup
 nav_order: 3
 ---
 

--- a/upload_firmware_guide.md
+++ b/upload_firmware_guide.md
@@ -6,7 +6,7 @@ has_children: true
 
 # Updating the tracker firmware
 
-This procedure will show how to build the SlimeVR firmware and upload it to your tracker.
+This procedure will show how to build and configure the SlimeVR firmware and upload it to your tracker.
 
 ## 1. Build your tracker
 

--- a/upload_firmware_guide.md
+++ b/upload_firmware_guide.md
@@ -1,13 +1,12 @@
 ---
 layout: page
-title: Updating SlimeVR Tracker firmware
 nav_order: 2
 has_children: true
 ---
 
-# Updating SlimeVR Tracker firmware
+# Updating the tracker firmware
 
-This will show how to upload firmware to your ESP.
+This procedure will show how to build the SlimeVR firmware and upload it to your tracker.
 
 ## 1. Build your tracker
 
@@ -33,15 +32,19 @@ Once installed we need to install PlatformIO, a plug-in that allows us to connec
 
 ## 4. Install device drivers
 
-You can download the drivers for Windows for CP210X (NodeMCU v2) from silicon labs [here](https://www.silabs.com/documents/public/software/CP210x_Universal_Windows_Driver.zip).
+### For CP210X (NodeMCU v2)
 
-For any other OS, drivers can be found [here](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers).
+1. Download the zip archive with the drivers from silicon labs [here](https://www.silabs.com/documents/public/software/CP210x_Universal_Windows_Driver.zip).
 
-For CH340 (NodeMCU v3 and **review units of SlimeVR**), download the drivers from [here](https://cdn.sparkfun.com/assets/learn_tutorials/8/4/4/CH341SER.EXE).
+   For any other OS, the drivers can be found [here](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers).
 
-### Extract the files then launch `CP210xVCPInstaller_x64.exe` as shown for CP210X, for CH430, launch the file named `CH341SER.EXE`
+1. Extract the files from the downloaded zip archive, then launch `CP210xVCPInstaller_x64.exe` (`CP210xVCPInstaller_x86.exe` if you are using 32-bit Windows) and follow installation instructions.
 
 ![img](https://i.imgur.com/9Ztro0h.gif)
+
+### For CH340 (NodeMCU v3 and review units of SlimeVR)
+
+Download the `CH341SER.EXE` file from [here](https://cdn.sparkfun.com/assets/learn_tutorials/8/4/4/CH341SER.EXE), run it and follow installation instructions.
 
 ## 5. Install git client
 
@@ -51,7 +54,7 @@ _Note: you will most likely have to click "Click here to download manually". If 
 
 ![img](https://i.imgur.com/wam3ea1.gif)
 
-## 6. Download Firmware
+## 6. Download the firmware
 
 * Create folder for SlimeVR firmware, open powershell or cmd in that folder and execute this command: `git clone https://github.com/SlimeVR/SlimeVR-Tracker-ESP.git`.
 * Once cloned, open the file the project in Visual Studio Code by opening PIO home, selecting open project, then navigate to the folder that the SlimeVR firmware is in. Example: `C:\Users\YOUR_USERNAME\Downloads\SlimeVR-Tracker-ESP-main\SlimeVR-Tracker-ESP-main`.
@@ -66,19 +69,18 @@ Insert the Micro-USB cable from your computer while holding down the button labe
 
 ## 8. Build your firmware
 
-1. Change the `platformio.ini` file by following the instructions described in [Configuring PlatformIO project](configuring_project.md#configuring-platformio-project).
-1. Change the `defines.h` file by following the instructions described in [Configuring defines.h](configuring_project.md#configuring-definesh).
-1. Press build button on bottom of Visual Studio Code.
+1. Follow the [Updating the tracker's firmware](configuring_project.md) to prepare your project for building and uploading the firmware.
+1. Press the build button at the bottom of Visual Studio Code.
 
    ![img](https://i.imgur.com/EmSkhFp.png)
 
 ## 9. Upload your firmware
 
-* Once the firmware has been built press the upload button to upload firmware.
+* Once the firmware has been built, press the upload button to upload the firmware.
 
   ![img](https://i.imgur.com/lI3PFVC.png)
 
-* If the upload is successful you should get an output that looks like this:
+* If the upload is successful, you should get an output that looks like this:
 
   ![img](https://i.imgur.com/SDQcCr1.png)
 

--- a/upload_firmware_guide.md
+++ b/upload_firmware_guide.md
@@ -26,7 +26,7 @@ Download the [latest Visual Studio Code](https://code.visualstudio.com/download)
 
 ## 3. Install PlatformIO IDE
 
-Once installed we need to install PlatformIO, a plug-in that allows us to connect to the tracker and upload the firmware.
+Once Visual Studio Code is installed, open it and install [PlatformIO IDE for VSCode](https://marketplace.visualstudio.com/items?itemName=platformio.platformio-ide), an extension that will allow us to connect to the tracker, build and upload the firmware.
 
 ![img](https://i.imgur.com/ebV0IgT.gif)
 
@@ -54,10 +54,13 @@ _Note: you will most likely have to click "Click here to download manually". If 
 
 ![img](https://i.imgur.com/wam3ea1.gif)
 
-## 6. Download the firmware
+## 6. Clone the firmware project
 
-* Create folder for SlimeVR firmware, open powershell or cmd in that folder and execute this command: `git clone https://github.com/SlimeVR/SlimeVR-Tracker-ESP.git`.
-* Once cloned, open the file the project in Visual Studio Code by opening PIO home, selecting open project, then navigate to the folder that the SlimeVR firmware is in. Example: `C:\Users\YOUR_USERNAME\Downloads\SlimeVR-Tracker-ESP-main\SlimeVR-Tracker-ESP-main`.
+1. Open Powershell window or Command Prompt window in the folder where you want to clone the firmware project, and execute the following command: `git clone https://github.com/SlimeVR/SlimeVR-Tracker-ESP.git SlimeVR-Tracker-ESP-main`.
+1. Once the project is cloned, open the project in Visual Studio Code:
+   1. Click the **PlatformIO** icon on the Activity Bar.
+   1. Select **PIO Home** > **Open**.
+   1. In the opened tab, click **Open Project** under Quick Access section, then navigate to the cloned firmware project folder.
 
 ![img](https://i.imgur.com/G0egnh6.gif)
 


### PR DESCRIPTION
* Fix typo in word "corresponds"
* Use h1 as heading and title instead of duplicating it
* Move common "To use the ... project" from configuration sections to procedure overview
* "Configuring PlatformIO project" -> "Configuring platformio.ini" since we talk about files now