### PR TITLE
Changed Common Issue for trackers not showing up in SteamVR

### DIFF
--- a/common-issues.md
+++ b/common-issues.md
@@ -63,7 +63,8 @@ If you are still having trouble, try manually adding the SlimeVR Server to your 
 
 ## The trackers are connected to the SlimeVR server but aren't turning up on Steam
 
--Make sure that you have the right SteamVR driver installed or install SlimeVR with [the installer](https://github.com/SlimeVR/SlimeVR-Installer/releases/download/v0.1.4/slimevr_web_installer.exe).
+- Make sure you installed SlimeVR with [the installer](https://github.com/SlimeVR/SlimeVR-Installer/releases/latest/download/slimevr_web_installer.exe) to have the right SteamVR driver.
+- Make sure the SlimeVR addon is enabled in SteamVR Settings > Startup/Shutdown > Manage Add-ons.
 
 ## My trackers are bound to the wrong controllers in SteamVR
 

--- a/common-issues.md
+++ b/common-issues.md
@@ -63,9 +63,7 @@ If you are still having trouble, try manually adding the SlimeVR Server to your 
 
 ## The trackers are connected to the SlimeVR server but aren't turning up on Steam
 
-There are two common causes that you should check:
-- Make sure that you have the right driver installed.
-- SlimeVR should always be launched before SteamVR. Close both and then launch SlimeVR Server before launching SteamVR.
+-Make sure that you have the right SteamVR driver installed or install SlimeVR with [the installer](https://github.com/SlimeVR/SlimeVR-Installer/releases/download/v0.1.4/slimevr_web_installer.exe).
 
 ## My trackers are bound to the wrong controllers in SteamVR
 


### PR DESCRIPTION
SlimeVR doesn't need to be launched before SteamVR anymore.
Now tell the user to use the installer to have the right driver and to make sure they have the steamvr slimevr addon enabled in steamvr settings.