### PR TITLE
Made a small syntax mistake

### DIFF
--- a/diy/cases.md
+++ b/diy/cases.md
@@ -18,7 +18,7 @@ The SlimeVR community has built a huge number of cases for style, internals and 
 
 * Customisable, see the github for more information.
 * D1 Mini
-* MPU6050 | MPU9250 | BNO085
+* MPU6050, MPU9250 & BNO085
 * Various battery sizes and switch types
 
 [Github](https://github.com/Smeltie/Hyperion)


### PR DESCRIPTION
the syntax | in the previous version causes: 
![image](https://user-images.githubusercontent.com/38034111/151634074-7aad06f8-3a36-48e1-bd19-33f0823d843e.png)
So yeah fixed that.

Only the docs version of MD does that Github preview didn't show it.