### PR TITLE
Added additional WiFi Hardcode information

### DIFF
--- a/firmware/configuring-project.md
+++ b/firmware/configuring-project.md
@@ -67,6 +67,7 @@ To hardcode your wifi credentials, uncomment the following lines and replace `SS
   -DWIFI_CREDS_PASSWD='"PASSWORD"'
 ```
 
+You can find these lines in the: "platformio.ini" file.  
 If you are having problems getting the tracker to connect to your Wi-Fi, review these troubleshooting steps:
 
 - If your wifi password contains the `%` character, replace it with `%%`.


### PR DESCRIPTION
It was not specified in which file someone can hard code the Wi-Fi hence why I added this line.
Not that it's hard to find but it saves time and makes the setup guide easier to follow.
It shows them in the platform.ini photo up top but i've seen people ask where to find them so it's a small addition that makes life easier.