### PR TITLE
IMU (MPU9250/BMI160) calibration moved, magnetometer clarifications, minor spelling/grammar fixes

### DIFF
--- a/common-issues.md
+++ b/common-issues.md
@@ -56,10 +56,6 @@ In order to make sure your aux tracker is set up, you need to specify it in your
 
 Check your INT wire, there is either a bad connection or you have it connected to the flash pin. If you are building your tracker on a breadboard, your connections may be not firm enough and cause this error.
 
-## I'm not getting any sensor data. (How to calibrate)
-
-Certain IMUs, such as the MPU9250, need to calibrated before they will give sensor data. To do this, plug in your microcontroller (D1 Mini, NodeMCU, or other) and open the SlimeVR server, and click "WiFi". Then, flip your IMUs you want to calibrate upside down and press the reset button on your micro controller. You should see a message indicating that you need to flip the IMU over to begin calibration. Upon flipping the IMU over, calibration should begin. To successfully calibrate your IMU you need to gently rotate the IMU in all 3 axes. Once 30 seconds has passed, the tracker should be successfully calibrated and will begin to show rotation in the SlimeVR server.
-
 ## The trackers are connected to my wifi but don't turn up on SlimeVR
 
 Check that you do not have two copies of the SlimeVR server running, as only one of them will show trackers connected.
@@ -106,4 +102,4 @@ You may have specified a wrong `IMU_ROTATION` value in your `defines.h` file. Ta
 * [BNO08X calibration documentation](https://xdevs.com/doc/CEVA/BNO080-BNO085-Sesnor-Calibration-Procedure.pdf)
 * [MPU-9250 product specification](https://invensense.tdk.com/wp-content/uploads/2015/02/PS-MPU-9250A-01-v1.1.pdf)
 
-*Created and updated by CalliePepper#0666, edited by Emojikage#3095, Spazzwan#0001 and NWB#5135*
+*Created and updated by CalliePepper#0666, edited by Emojikage#3095, Spazzwan#0001*

--- a/diy/imu-comparison.md
+++ b/diy/imu-comparison.md
@@ -174,17 +174,17 @@ Score: <i class="fa fa-star"></i><i class="fa fa-star"></i><i class="fa fa-star-
 ---
 # Addendum
 
-## How can I check if I have an acceptable magnegic environment?
+## How can I check if I have an acceptable magnetic environment?
 
-You can check by downloading any magnetometer app that show what your magnetic field strength is in uT. An option available on both iOS and Android is the app, Physics Toolbox Magnetometer. If you do use Physics Toolbox Magnetometer, you only need to pay attention to the total, not the X, Y, or Z components. Most phones have a magnetometer, but if yours does not, then there is no way to be exactly sure of your magnetic environment, but you can make some educated assumptions.
+You can check by downloading any magnetometer app that show what your magnetic field strength is in uT and by walking around your playspace. You may want to check at varying heights, such as at chest level, waist level, and ankle level. An option available on both iOS and Android is the app, Physics Toolbox Magnetometer. If you do use Physics Toolbox Magnetometer, you only need to pay attention to the total, not the X, Y, or Z components. Most phones have a magnetometer, but if yours does not, then there is no way to be exactly sure of your magnetic environment, but you can make some educated assumptions.
 
 ## My app show around X uT is that okay?
 
-There's no one value that's acceptable. What matters is that the range of values is low. There is currently limited data to give an exact range, but a good baseline seems to be a range of less than or equal to 5 uT. 
+There's no one value that's acceptable. What matters is that the range of values is low. There is currently limited data to give an exact range, but a good baseline seems to be a range of less than or equal to 5 uT. For example, 20-25 uT would be okay as would 40-45 uT, but a range of 20-40 uT would likely be too unstable to use.
 
 ## What determines a "poor magnetic environment"?
 
-Often things made of steel or other ferromagnetic materials contribute most to a poor magnetic environment. Some common examples of things that might affect your magnetic environment include, but are not limited to: spring mattresses, radiators, PC cases, desktop speakers, or furniture that's made of steel. In most cases, the effect that these things will have extend about 6-12 inches (15-30 cm) and within that range may cause the IMU to rotate incorrectly. The size and amount of mass directly impacts the size of the effected area; a paper clip might only affect your IMU if it's directly next to it, whereas a steel bedframe might affect an area 6-12 inches (15-30 cm) away as previous mentioned. In most cases, depending on the size of your playspace, these issues of certain objects causing interference can be mitigated by avoiding or reposition them. Regardless, other factors such as the wiring or rebar in your building could also affect your magnetic environment. These last few examples are harder predict and illustrate why it's important to test with an app before assuming you might have a stable magnetic environment.
+Often things made of steel or other ferromagnetic materials contribute most to a poor magnetic environment. Some common examples of things that might affect your magnetic environment include, but are not limited to: spring mattresses, radiators, PC cases, desktop speakers, or furniture that's made of steel. In most cases, the effect that these things will have extend about 6-12 inches (15-30 cm) and within that range may cause the IMU to rotate incorrectly. The size and amount of mass directly impacts the size of the effected area; a paper clip might only affect your IMU if it's directly next to it, whereas a steel bedframe might affect an area 6-12 inches (15-30 cm) away as previous mentioned. In most cases, depending on the size of your playspace, these issues of certain objects causing interference can be mitigated by avoiding or reposition them. Regardless, other factors such as the wiring or rebar in your building could also affect your magnetic environment. These last few examples are harder to predict and illustrate why it's important to test with an app before assuming you might have a stable magnetic environment.
 
 ## Can I still use my IMU with a magnetometer if I don't have a stable magnetic environment?
 

--- a/index.md
+++ b/index.md
@@ -26,7 +26,7 @@ You get yourself a **microcontroller**, an **IMU** [(supported IMUs)](https://gi
 
 **Cons:** You will need to solder some wires, have a basic understanding of electronics, and you are limited in how small the trackers can get. DIY builds require time to assemble and may require self repairs from time to time.
 
-> **Caution:** There is a seller on Amazon selling DIY SlimeVR tracers. Due a significant number of users reporting issues with these trackers, they cannot be recommended unless you are savvy enough to potentially diagnose any issues as if you were DIY'ing SlimeVR trackers yourself. If you purchase them, you are doing so at your own risk.
+> **Caution:** There is a seller on Amazon selling DIY SlimeVR trackers. Due a significant number of users reporting issues with these trackers, they cannot be recommended unless you are savvy enough to potentially diagnose any issues as if you were DIY'ing SlimeVR trackers yourself. If you purchase them, you are doing so at your own risk.
 
 ### 2. Pre-order the official DIY Kit on Crowd Supply
 

--- a/server-setup/installing-and-connecting.md
+++ b/server-setup/installing-and-connecting.md
@@ -15,7 +15,9 @@ The latest [SlimeVR Installer can be found here.](https://github.com/SlimeVR/Sli
 ## Test your trackers
 Turn each tracker on and see if they work.
 
-Make sure that when you turn on your tracker, it's lying on a flat surface. The sensors need to calibrate for 10-20 seconds in a stable environment (dependent on the model of your IMU).
+Make sure that when you turn on your tracker, it's lying on a flat surface. The sensors need to calibrate for 10-20 seconds in a stable environment (dependent on the model of your IMU). This should be done every time you turn on your trackers.
+
+If you have an MPU9250 or a BMI160, you need to first calibrate the IMU before it will show rotation. This only needs to be done once. To do this, plug in your microcontroller (D1 Mini, NodeMCU, or other) and open the SlimeVR server, and click "WiFi". Then, flip your IMUs you want to calibrate upside down and press the reset button on your micro controller. You should see a message indicating that you need to flip the IMU right side up to begin calibration. Upon flipping the IMU over, calibration should begin. To successfully calibrate your IMU you need to gently rotate the IMU in all 3 axes. Once 30 seconds has passed, the tracker should be successfully calibrated and will begin to show rotation in the SlimeVR server.
 
 Each tracker should blink a LED briefly on startup, and then blink every few seconds to indicate its status as follows:
 
@@ -71,4 +73,4 @@ If any tracker displays ERROR as it's status, or have orange and blue light perm
 
 ***Next step - [Configuring the trackers](configuring-trackers.md)***
 
-*Created by Eiren, edited by adigyran#1121, CalliePepper#0666 and Emojikage#3095, styled by CalliePepper#0666.*
+*Created by Eiren, edited by adigyran#1121, CalliePepper#0666, Emojikage#3095 and NWB#5135, styled by CalliePepper#0666.*


### PR DESCRIPTION
Moved IMU calibration from common issues to the "Test your trackers" section of "Installing the server and connecting your trackers" since this is where people are most likely to find the IMUs seemingly not working, when in reality they just need to be calibrated. Added some clarification regarding what uT ranges are acceptable, and how exactly magnetic environment should be tested (need to walk around playspace). Final changes were minor spelling fixes.