### PR TITLE
Add note for OVRAS' keybindings in other languages

### DIFF
--- a/server-setup/setting-reset-bindings.md
+++ b/server-setup/setting-reset-bindings.md
@@ -48,6 +48,7 @@ Make sure OVR Advanced Settings is closed before following these steps or you wi
 ## Notes
 
 - If you reset your playspace (for example long pressing Oculus button on Quest), you will need to do a [tracker reset](#reset-trackers).
+- OpenVR Advanced Settings' keybinds may not work well in certain languages. If this is the case for you, start SteamVR with your system's language set to English.
 - SlimeVR Server uses [Java 11](https://adoptium.net/releases.html?variant=openjdk11&jvmVariant=hotspot).
 - If you need the SlimeVR Steam driver you can find it [here](https://github.com/SlimeVR/SlimeVR-OpenVR-Driver/releases/latest/download/slimevr-openvr-driver-win64.zip).
 


### PR DESCRIPTION
Context: TheSkyner#8815 on Discord reported that OVRAS's keybindings don't work if their system language is in Russian but works in English.