### PR TITLE
Change 4+1 battery link to 5 battery link.

### DIFF
--- a/diy/components-guide.md
+++ b/diy/components-guide.md
@@ -77,7 +77,7 @@ The MPUs are much easier to purchase and does not suffer from availability issue
 
 ### Batteries
 
-There are a bunch of options for batteries, but the most commonly used is a 3.7v Li-ion Polymer battery in the 804040 form factor. You need one per each Wemos D1 Mini you're using. These are easily purchased at Aliexpress in both a 10 pack for $24 ([Aliexpress](https://www.aliexpress.com/item/1005002559604104.html)) or a 4 pack (you will need to get one additional) [Aliexpress](https://www.aliexpress.com/item/33021202630.html) ($15 total).
+There are a bunch of options for batteries, but the most commonly used is a 3.7v Li-ion Polymer battery in the 804040 form factor. You need one per each Wemos D1 Mini you're using. These are easily purchased at Aliexpress in both a 10 pack for $24 ([Aliexpress](https://www.aliexpress.com/item/1005002559604104.html)) or a 5 pack [Aliexpress](https://www.aliexpress.com/item/3256803961495200.html) ($15).
 
 ### Charging board - TP4056
 


### PR DESCRIPTION
Old link (https://www.aliexpress.com/item/33021202630.html) was broken and did not lead anywhere, and I just so happened to find a 5 battery set of exactly the same type of batteries (EHAO 804040) as the set of 10 for probably the same price? I am unsure whether to include delivery price or current discount, but basic price is $15 currently.