### PR TITLE
Defines.h Settings Clarification, and Additional Common Issue

### DIFF
--- a/assets/js/configuring-defines.js
+++ b/assets/js/configuring-defines.js
@@ -170,6 +170,7 @@
                 'IMU_MPU6050': 'MPU6050',
                 'IMU_ICM20948': 'ICM20948',
                 'IMU_BMI160' : 'BMI160',
+                'IMU' : 'None'
             },
             action: (vals) => { return {imu_2: vals.imu_2}; }
         },

--- a/common-issues.md
+++ b/common-issues.md
@@ -75,9 +75,11 @@ If you are still having trouble, try manually adding the SlimeVR Server to your 
 ## The trackers are connected to the SlimeVR server but aren't showing up
 
 This is usually the result of an issue with the IMU. Plug in your Wemos D1 Mini and check either through the WiFi menu in the old server, or via the serial console under settings in the new UI. You may see an error like one of the following:
-`[ERR] I2C: Can't find I2C device on provided addresses, scanning for all I2C devices and returning`
-`[ERR] I2C: No I2C devices found`
-`[ERROR] [ErroneousSensor:0] IMU of type MPU6500 failed to initialize`
+```c
+[ERR] I2C: Can't find I2C device on provided addresses, scanning for all I2C devices and returning
+[ERR] I2C: No I2C devices found
+[ERROR] [ErroneousSensor:0] IMU of type MPU6500 failed to initialize
+```
 
 The most common reasons for errors with the IMU are the following:
 1. You accidentally set the IMU wrong (i.e. set as MPU6050 when you have an BNO085)

--- a/common-issues.md
+++ b/common-issues.md
@@ -72,6 +72,20 @@ If you are still having trouble, try manually adding the SlimeVR Server to your 
 1. Click the **Add** button to add the file to your firewall settings.
 1. Finally, make sure both public and private check boxes are selected in the **Allowed apps** window before clicking **OK** to save the changes.
 
+## The trackers are connected to the SlimeVR server but aren't showing up
+
+This is usually the result of an issue with the IMU. Plug in your Wemos D1 Mini and check either through the WiFi menu in the old server, or via the serial console under settings in the new UI. You may see an error like one of the following:
+`[ERR] I2C: Can't find I2C device on provided addresses, scanning for all I2C devices and returning`
+`[ERR] I2C: No I2C devices found`
+`[ERROR] [ErroneousSensor:0] IMU of type MPU6500 failed to initialize`
+
+The most common reasons for errors with the IMU are the following:
+1. You accidentally set the IMU wrong (i.e. set as MPU6050 when you have an BNO085)
+1. The wiring is wrong (e.g. accidentally swapping around D1/D2 and SDA/SCL)
+1. There's an issue with the soldering (e.g. not enough solder, cold joint, or bridging between SDA and SCL)
+1. You're using a breadboard (Without soldering connections, the IMU often won't be able to communicate with the microcontroller)
+1. There's an issue with the IMU itself (e.g. burned trace while soldering, or the chip is downright DOA)
+
 ## The trackers are connected to the SlimeVR server but aren't turning up on Steam
 
 - Make sure you installed SlimeVR with [the installer](https://github.com/SlimeVR/SlimeVR-Installer/releases/latest/download/slimevr_web_installer.exe) to have the right SteamVR driver.

--- a/diy/components-guide.md
+++ b/diy/components-guide.md
@@ -73,7 +73,7 @@ It's also worth noting that not all batteries are created equal. Some will have 
 
 ### Charging Board - TP4056
 
-To charge the batteries above, you need to get a charge controller that will make sure the batteries are safely charged. Bear in mind, without diodes, you can potentially damage your battery if you accidentally leave your tracker on while charging. That being said, the TP4056 charging boards also provide some safety features such as over-discharge protection, over-charging protection (only when turned off!), short circuit protection, and over current protection.
+To charge your batteries, you need to get a charge controller to make sure the batteries are safely charged. Bear in mind, without diodes, you can potentially damage your battery if you accidentally leave your tracker on while charging. That being said, the TP4056 charging boards also provide some safety features such as over-discharge protection, over-charging protection (only when turned off if you don't have [diodes](#diodes-optional)!), short circuit protection, and over current protection.
 
 ### Power Switches
 

--- a/diy/components-guide.md
+++ b/diy/components-guide.md
@@ -69,9 +69,11 @@ There are many different options for batteries, and the size you go with will ge
 
 Flat Li-Po batteries are generally fairly truthful about their capacity, however, 18650s can greatly vary in capacity depending on manufacturer. A generic no-name 18650 could be as low in capacity as 800 mAh, whereas an 18650 made by a reputable manufacturer like LG, Samsung, or Sony may have as high capacity at 3500 mAh. In general, be suspicious of claimed 18650 capacity.
 
+It's also worth noting that not all batteries are created equal. Some will have protection protection circuitry and some will not. Generally speaking, flat Li-Po batteries will usually have protection circuitry, whereas battery such as 18650s will not. If you're planning on getting flat Li-Po batteries, the protection circuitry will usually look like a small PCB with a few chips on it, beneath the yellow polyimide tape on the battery. That being said, the [TP4056 charging board](#charging-board---tp4056) will provide these same features so lack of battery protection shouldn't be a make or break factor, but rather additional peace of mind and added safety.
+
 ### Charging Board - TP4056
 
-To charge the batteries above, you need to get a charge controller that will make sure the batteries are safely charged. Bear in mind, without diodes, you can potentially damage your battery if you accidentally leave your tracker on while charging.
+To charge the batteries above, you need to get a charge controller that will make sure the batteries are safely charged. Bear in mind, without diodes, you can potentially damage your battery if you accidentally leave your tracker on while charging. That being said, the TP4056 charging boards also provide some safety features such as over-discharge protection, over-charging protection (only when turned off!), short circuit protection, and over current protection.
 
 ### Power Switches
 

--- a/firmware/configuring-project.md
+++ b/firmware/configuring-project.md
@@ -129,18 +129,17 @@ The following line defines which IMU is present:
 To change IMU model, replace `IMU_BNO085` with one of the following values depending on your IMU model:
 
 ```
-MPU9250
-MPU6500
-BNO080
-BNO085
-BNO055
-MPU6050
-BNO086
-BMI160
-ICM20948
+IMU_BNO080
+IMU_BNO055
+IMU_MPU9250
+IMU_MPU6500
+IMU_MPU6050
+IMU_BNO086
+IMU_ICM20948
+IMU_BMI160
 ```
 
-If you're using an MPU+QMC5883L, you would set your IMU as `IMU_MPU9250`.
+If you're using an MPU+QMC5883L, you would set your IMU as `IMU_MPU9250`. Bear in mind, you would to be using the QMC firmware for this to work, as the main firmware does not support the MPU+QMC5883L.
 
 ##### Change board model
 
@@ -169,7 +168,20 @@ To change the IMU board rotation, replace `DEG_90` (and `DEG_270` if you have au
 
 ![](../assets/img/rotation.png)
 
+##### Set battery monitoring options
+
+The following lines define how battery voltage is read:
+
+```c
+#define BATTERY_MONITOR BAT_EXTERNAL
+#define BATTERY_SHIELD_RESISTANCE 180
+```
+
+If you don't have a 180 kOhm resistor for checking the battery percentage of your tracker, replace `BAT_EXTERNAL` with `BAT_INTERNAL`. When set to `BAT_INTERNAL` the tracker will only be able to tell when the battery is low, and will cause the LED on the microcontroller to flash repeatedly. If you have a 180 kOhm resistor you do not need to change `BAT_EXTERNAL`. If you have a resistor of value other than 180 kOhm, simply change `180` to whatever your resistor value is in kOhms, for instance `130` if your resistor is 130 kOhms. If you have a Wemos Battery Shield product, you would change `180` to `130` as previously mentioned.
+
 #### Define pins of the selected board
+
+You need to change only the section between `#elif` symbols with the selected board. If you are using VSCode, selected board section will light up, while other ones will be grayed out.
 
 **Example 1:**
 
@@ -228,9 +240,11 @@ If you are using the second BNO you need to define INT pin for the second BNO, i
   #define PIN_IMU_INT_2 D6
 ```
 
-You need to change only the section between `#elif` symbols with the selected board. If you are using VSCode, selected board section will light up, while other ones will be grayed out.
+If you are using a resistor for checking the battery level, you will need to select a pin that supports analog input:
 
-_Battery level pin guide WIP._
+```c
+  #define PIN_BATTERY_LEVEL A0
+```
 
 
 
@@ -238,6 +252,6 @@ Your firmware for your MCU and IMU configuration should now be complete!
 
 ***Next step - [Uploading the firmware](upload-firmware.md)***
 
-*Created by adigyran#1121 with help from Musicman247#1341, edited and styled by CalliePepper#0666 and Emojikage#3095*
+*Created by adigyran#1121 with help from Musicman247#1341, edited by NWB#5135, edited and styled by CalliePepper#0666 and Emojikage#3095*
 
 <script src="../assets/js/configuring-defines.js"></script>

--- a/firmware/upload-firmware.md
+++ b/firmware/upload-firmware.md
@@ -58,7 +58,7 @@ Once you have successfully connected your trackers to your WiFi, you can use OTA
   ```
 1. Change the value of upload_port to the IP address retrieved during the first step (if retrieved for your SlimeVR server you should only copy the set of 4 numbers between the second and third `/`, in the example image above this would be 192.168.1.109).
 1. Turn the tracker you wish to flash off and then on again.
-1. Wait around 5 seconds.
+1. Wait for the tracker to reconnect to the server.
 1. Press the upload button to upload the firmware.<br>  
   ![img](https://i.imgur.com/lI3PFVC.png)
 1. Repeat for as many trackers as you need.
@@ -69,4 +69,4 @@ If you encountered an issue while following these steps check the [Common issues
 
 If you don't find an answer to your question there ask in **#diy** channel in [the discord](https://discord.gg/slimevr), we will be happy to help.
 
-*Made with care by Prohurtz#0001, adigyran#1121, Eiren#0666 and CalliePepper#0666. Edited by CalliePepper#0666 and Emojikage#3095.*
+*Made with care by Prohurtz#0001, adigyran#1121, Eiren#0666 and CalliePepper#0666. Edited by CalliePepper#0666, Emojikage#3095, and NWB#5135.*


### PR DESCRIPTION
Added the long since missing, "battery level pin guide", added an option for "None" to the defines.h generator for aux IMUs, and added an additional section to the common issues page regarding why a tracker might be able to connect and yet not show up in the SlimeVR server.