### PR TITLE
Add warning about incomplete OTAs.

### DIFF
--- a/firmware/upload-firmware.md
+++ b/firmware/upload-firmware.md
@@ -61,6 +61,7 @@ Once you have successfully connected your trackers to your WiFi, you can use OTA
 1. Wait for the tracker to reconnect to the server.
 1. Press the upload button to upload the firmware.<br>  
   ![img](https://i.imgur.com/lI3PFVC.png)
+1. After the upload reaches 100%, wait for the tracker to reconnect to the server again. Turning the device off too soon can result in an incomplete update (bricked until you upload new firmware over USB).
 1. Repeat for as many trackers as you need.
 
 ## Troubleshooting
@@ -69,4 +70,4 @@ If you encountered an issue while following these steps check the [Common issues
 
 If you don't find an answer to your question there ask in **#diy** channel in [the discord](https://discord.gg/slimevr), we will be happy to help.
 
-*Made with care by Prohurtz#0001, adigyran#1121, Eiren#0666 and CalliePepper#0666. Edited by CalliePepper#0666, Emojikage#3095, and NWB#5135.*
+*Made with care by Prohurtz#0001, adigyran#1121, Eiren#0666 and CalliePepper#0666. Edited by CalliePepper#0666, Emojikage#3095, NWB#5135, and Tony#9719.*


### PR DESCRIPTION
This is something I ran into with my trackers, and NWB believes that they were affected by this too.

Turning the tracker off *right* after an OTA, even if it says "Update Success" in VS Code, will temporarily brick the tracker until you re-flash it over USB. After the upload, the ESP processes (likely checksumming) the update, and then reboots into the new firmware. During that processing is when I, and likely others, have temporarily borked ourselves.