### PR TITLE
Add Jekyll page redirects

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -37,4 +37,17 @@ cname = "docs.slimevr.dev"
 no-section-label = true
 
 [output.html.redirect]
-"slimevr-experience-survey.html" = "misc/survey.html"
+"/slimevr-experience-survey.html" = "/misc/survey.html"
+"/diy/diy-trackers-guide.html" = "/diy/index.html"
+"/firmware/updating-firmware.html" = "/firmware/index.html"
+"/tools/applications-and-variants.html" = "/tools/index.html"
+
+# Server setup pages ("server-setup" -> "server")
+"/server-setup/body-config.html" = "/server/body-config.html"
+"/server-setup/configuring-trackers.html" = "/server/configuring-trackers.html"
+"/server-setup/connecting-trackers.html" = "/server/connecting-trackers.html"
+"/server-setup/initial-setup.html" = "/server/initial-setup.html"
+"/server-setup/osc-information.html" = "/server/osc-information.html"
+"/server-setup/putting-on-trackers.html" = "/server/putting-on-trackers.html"
+"/server-setup/setting-reset-bindings.html" = "/server/setting-reset-bindings.html"
+"/server-setup/slimevr-setup.html" = "/server/index.html"


### PR DESCRIPTION
- Redirects all index pages to the appropriate `index.html` pages
- Redirects all `server-setup` pages to `server`