### PR TITLE
fix: firmware url link

### DIFF
--- a/src/firmware/README.md
+++ b/src/firmware/README.md
@@ -2,7 +2,7 @@
 
 This procedure will show how to build and configure the SlimeVR firmware, as well as how to upload it to your tracker.
 
-There are currently two ways of uploading your firmware. One is using PlatformIO, and the other is the [online firmware flasher](https://slimevr-firmware-tool.futurabeast.com/). The online flasher is the most user friendly but doesn't work with Safari or Firefox. 
+There are currently two ways of uploading your firmware. One is using PlatformIO, and the other is the [online firmware flasher](https://slimevr-firmware-tool.futurabeast.com/). The online flasher is the most user friendly but doesn't work with Safari or Firefox.
 
 <div class="embeddedVideo">
 	<video controls="controls" width="800" height="600" name="Firmware Tools Example">
@@ -15,6 +15,6 @@ If you're interested in using experimental firmware, you can use the [Butterscot
 
 The PlatformIO version is less user friendly, but is recommended if you want to get into the nitty gritty of developing the firmware. The following pages will walk you through the process of manually flashing your trackers. The guide assumes you have working and complete trackers, and are going to be using the platformio approach. All screenshots are for a Windows based system.
 
-1. [Setting up the Environment](firmware/setup-and-install.md)
-2. [Configuring the Firmware](firmware/configuring-project.md)
-3. [Building and Uploading the Firmware](firmware/upload-firmware.md)
+1. [Setting up the Environment](setup-and-install.md)
+2. [Configuring the Firmware](configuring-project.md)
+3. [Building and Uploading the Firmware](upload-firmware.md)


### PR DESCRIPTION
recently trying to DIY IMU Tracker, found out the link is not working

Ref: https://docs.slimevr.dev/firmware/index.html