### PR TITLE
Actually capitalised PlatformIO correctly

### DIFF
--- a/po/en/messages.pot
+++ b/po/en/messages.pot
@@ -2277,7 +2277,7 @@ msgid ""
 "- Check if your Wi-Fi has reached it's maximum allowed Wi-Fi connections. "
 "You can test this by disconnecting devices and then trying to connect your "
 "trackers again.\n"
-"- If you hard coded your Wi-Fi settings in `PlatformIO.ini` try connecting "
+"- If you hard coded your Wi-Fi settings in `platformio.ini` try connecting "
 "your trackers via usb and [pushing new Wi-Fi "
 "details](server/connecting-trackers.md#connect-trackers). You may find this "
 "either fixes your connection or provides you with additional details on why "
@@ -4997,7 +4997,7 @@ msgstr ""
 msgid ""
 "In order to build SlimeVR firmware and upload it to your tracker, you need "
 "to configure the project to match your specific hardware configuration. To "
-"do this, you need to modify two files: `PlatformIO.ini` and `defines.h`."
+"do this, you need to modify two files: `platformio.ini` and `defines.h`."
 msgstr ""
 
 #: src/firmware/configuring-project.md:5
@@ -5007,7 +5007,7 @@ msgstr ""
 
 #: src/firmware/configuring-project.md:7
 msgid ""
-"* [1. Configuring PlatformIO.ini](#1-configuring-PlatformIOini)\n"
+"* [1. Configuring platformio.ini](#1-configuring-PlatformIOini)\n"
 "  * [Select Your Hardware Settings](#select-your-hardware-settings)\n"
 "    * [Monitor Speed](#monitor-speed)\n"
 "    * [env](#env)\n"
@@ -5021,11 +5021,11 @@ msgid ""
 msgstr ""
 
 #: src/firmware/configuring-project.md:18
-msgid "## 1. Configuring PlatformIO.ini"
+msgid "## 1. Configuring platformio.ini"
 msgstr ""
 
 #: src/firmware/configuring-project.md:20
-msgid "The `PlatformIO.ini` file specifies the information about your MCU."
+msgid "The `platformio.ini` file specifies the information about your MCU."
 msgstr ""
 
 #: src/firmware/configuring-project.md:22
@@ -5033,15 +5033,15 @@ msgid "This file can be found in the root directory of the project:"
 msgstr ""
 
 #: src/firmware/configuring-project.md:24
-msgid "PlatformIO.ini file location"
+msgid "platformio.ini file location"
 msgstr ""
 
 #: src/firmware/configuring-project.md:26
-msgid "The contents of `PlatformIO.ini` file should look as follows:"
+msgid "The contents of `platformio.ini` file should look as follows:"
 msgstr ""
 
 #: src/firmware/configuring-project.md:28
-msgid "PlatformIO.ini file contents"
+msgid "platformio.ini file contents"
 msgstr ""
 
 #: src/firmware/configuring-project.md:30
@@ -5586,7 +5586,7 @@ msgid ""
 "through network monitoring applications, or by copying it from the SlimeVR "
 "Server as seen in the image below:<br>\n"
 "  ![tracker Ip](../assets/img/trackerIp.png)\n"
-"1. In `PlatformIO.ini` file uncomment the following lines in Visual Studio "
+"1. In `platformio.ini` file uncomment the following lines in Visual Studio "
 "Code by removing the `;`:"
 msgstr ""
 

--- a/po/es-419/messages.po
+++ b/po/es-419/messages.po
@@ -2232,7 +2232,7 @@ msgid ""
 "- Check if your Wi-Fi has reached it's maximum allowed Wi-Fi connections. You "
 "can test this by disconnecting devices and then trying to connect your "
 "trackers again.\n"
-"- If you hard coded your Wi-Fi settings in `PlatformIO.ini` try connecting "
+"- If you hard coded your Wi-Fi settings in `platformio.ini` try connecting "
 "your trackers via usb and [pushing new Wi-Fi details](server/connecting-"
 "trackers.md#connect-trackers). You may find this either fixes your connection "
 "or provides you with additional details on why the connection is failing."
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid ""
 "In order to build SlimeVR firmware and upload it to your tracker, you need to "
 "configure the project to match your specific hardware configuration. To do "
-"this, you need to modify two files: `PlatformIO.ini` and `defines.h`."
+"this, you need to modify two files: `platformio.ini` and `defines.h`."
 msgstr ""
 
 #: src/firmware/configuring-project.md:5 src/tools/owoTrack.md:10
@@ -4456,7 +4456,7 @@ msgstr ""
 
 #: src/firmware/configuring-project.md:7
 msgid ""
-"* [1. Configuring PlatformIO.ini](#1-configuring-PlatformIOini)\n"
+"* [1. Configuring platformio.ini](#1-configuring-PlatformIOini)\n"
 "  * [Select Your Hardware Settings](#select-your-hardware-settings)\n"
 "    * [Monitor Speed](#monitor-speed)\n"
 "    * [env](#env)\n"
@@ -4470,11 +4470,11 @@ msgid ""
 msgstr ""
 
 #: src/firmware/configuring-project.md:18
-msgid "## 1. Configuring PlatformIO.ini"
+msgid "## 1. Configuring platformio.ini"
 msgstr ""
 
 #: src/firmware/configuring-project.md:20
-msgid "The `PlatformIO.ini` file specifies the information about your MCU."
+msgid "The `platformio.ini` file specifies the information about your MCU."
 msgstr ""
 
 #: src/firmware/configuring-project.md:22
@@ -4482,15 +4482,15 @@ msgid "This file can be found in the root directory of the project:"
 msgstr ""
 
 #: src/firmware/configuring-project.md:24
-msgid "![PlatformIO.ini file location](https://i.imgur.com/CsBcxYL.png)"
+msgid "![platformio.ini file location](https://i.imgur.com/CsBcxYL.png)"
 msgstr ""
 
 #: src/firmware/configuring-project.md:26
-msgid "The contents of `PlatformIO.ini` file should look as follows:"
+msgid "The contents of `platformio.ini` file should look as follows:"
 msgstr ""
 
 #: src/firmware/configuring-project.md:28
-msgid "![PlatformIO.ini file contents](https://i.imgur.com/9EmR158.png)"
+msgid "![platformio.ini file contents](https://i.imgur.com/9EmR158.png)"
 msgstr ""
 
 #: src/firmware/configuring-project.md:30
@@ -4511,7 +4511,7 @@ msgstr ""
 #: src/firmware/configuring-project.md:36
 msgid ""
 "**For the platform and board fields, visit [PlatformIO Boards documentation]"
-"(https://docs.PlatformIO.org/en/latest/boards/index.html) and find your board "
+"(https://docs.platformio.org/en/latest/boards/index.html) and find your board "
 "there. If it's not there, keep default ones or ask on [SlimeVR Discord]"
 "(https://discord.gg/SlimeVR).**"
 msgstr ""
@@ -5049,7 +5049,7 @@ msgid ""
 "through network monitoring applications, or by copying it from the SlimeVR "
 "Server as seen in the image below:<br>\n"
 "  ![tracker Ip](../assets/img/trackerIp.png)\n"
-"1. In `PlatformIO.ini` file uncomment the following lines in Visual Studio "
+"1. In `platformio.ini` file uncomment the following lines in Visual Studio "
 "Code by removing the `;`:\n"
 "  ```ini\n"
 "  ;upload_protocol = espota\n"

--- a/src/common-issues.md
+++ b/src/common-issues.md
@@ -45,7 +45,7 @@ The two common issues that cause this error are:
 If all of this is correct, you can check your gateway's list of connected devices to see if all your trackers are connecting. If a tracker is not connecting even after using the same firmware upload with hardcoded Wi-Fi details there are two additional steps you can check:
 
 - Check if your Wi-Fi has reached its maximum allowed Wi-Fi connections. You can test this by disconnecting devices and then trying to connect your trackers again.
-- If you hard coded your Wi-Fi settings in `PlatformIO.ini` try connecting your trackers via USB and [pushing new Wi-Fi details](server/connecting-trackers.md#connect-trackers). You may find this either fixes your connection or provides you with additional details on why the connection is failing.
+- If you hard coded your Wi-Fi settings in `platformio.ini` try connecting your trackers via USB and [pushing new Wi-Fi details](server/connecting-trackers.md#connect-trackers). You may find this either fixes your connection or provides you with additional details on why the connection is failing.
 
 ## My aux tracker isn't working
 

--- a/src/firmware/configuring-project.md
+++ b/src/firmware/configuring-project.md
@@ -1,23 +1,23 @@
 # Configuring the Firmware Project
 
-In order to build SlimeVR firmware and upload it to your tracker, you need to configure the project to match your specific hardware configuration. To do this, you need to modify two files: `PlatformIO.ini` and `defines.h`.
+In order to build SlimeVR firmware and upload it to your tracker, you need to configure the project to match your specific hardware configuration. To do this, you need to modify two files: `platformio.ini` and `defines.h`.
 
 ## Table of Contents
 
 * TOC
 {:toc}
 
-## 1. Configuring PlatformIO.ini
+## 1. Configuring platformio.ini
 
-The `PlatformIO.ini` file specifies the information about your MCU.
+The `platformio.ini` file specifies the information about your MCU.
 
 This file can be found in the root directory of the project:
 
-![PlatformIO.ini file location](../assets/img/platformIniLocation.png)
+![platformio.ini file location](../assets/img/platformIniLocation.png)
 
-The contents of `PlatformIO.ini` file should look as follows:
+The contents of `platformio.ini` file should look as follows:
 
-![PlatformIO.ini file contents](../assets/img/platformIniContents.png)
+![platformio.ini file contents](../assets/img/platformIniContents.png)
 
 ### Select Your Hardware Settings
 
@@ -25,7 +25,7 @@ The contents of `PlatformIO.ini` file should look as follows:
 
 This field set your serial monitor speed in VSCode `monitor_speed = 115200`. Change this if your board datasheet and documentation suggest so, but the defaults should work.
 
-**For the platform and board fields, visit [PlatformIO Boards documentation](https://docs.PlatformIO.org/en/latest/boards/index.html) and find your board there. If it's not there, keep default ones or ask on [SlimeVR Discord](https://discord.gg/SlimeVR).**
+**For the platform and board fields, visit [PlatformIO Boards documentation](https://docs.platformio.org/en/latest/boards/index.html) and find your board there. If it's not there, keep default ones or ask on [SlimeVR Discord](https://discord.gg/SlimeVR).**
 
 #### env
 

--- a/src/firmware/setup-and-install.md
+++ b/src/firmware/setup-and-install.md
@@ -22,7 +22,7 @@ Download the [latest Visual Studio Code](https://code.visualstudio.com/download)
 
 ## 2. Install PlatformIO IDE
 
-Once Visual Studio Code is installed, open it and install [PlatformIO IDE for VSCode](https://marketplace.visualstudio.com/items?itemName=PlatformIO.PlatformIO-ide), an extension that will allow you to connect to the tracker, build and upload the firmware.
+Once Visual Studio Code is installed, open it and install [PlatformIO IDE for VSCode](https://marketplace.visualstudio.com/items?itemName=platformio.platformio-ide), an extension that will allow you to connect to the tracker, build and upload the firmware.
 
 <div class="embeddedVideo">
 	<video name="Installing PlatformIO" codecs='video/webm;codecs="vp9"' autoplay muted loop controls>

--- a/src/firmware/upload-firmware.md
+++ b/src/firmware/upload-firmware.md
@@ -39,7 +39,7 @@ Once you have successfully connected your trackers to your WiFi, you can use OTA
 
 1. Retrieve the IP of the tracker you wish to flash. The IP can be found through network monitoring applications, or by copying it from the SlimeVR Server as seen in the image below:<br>
   ![tracker Ip](../assets/img/trackerIp.png)
-1. In `PlatformIO.ini` file uncomment the following lines in Visual Studio Code by removing the `;`:
+1. In `platformio.ini` file uncomment the following lines in Visual Studio Code by removing the `;`:
   ```ini
   ;upload_protocol = espota
   ;upload_port = 192.168.1.49


### PR DESCRIPTION
Should be kept the same as before inside link and code (doesn't actually matter for links but it looks better