### PR TITLE
Note that GitHub account needed to download build artifacts

### DIFF
--- a/src/tools/linux-installation.md
+++ b/src/tools/linux-installation.md
@@ -20,6 +20,8 @@ Click on the title of the latest workflow run, this is simply an example and the
 
 Once you have the workflow run open, you can find a list of built artifacts. The simplest to use is the AppImage build since it includes all required dependencies and can be run very easily.
 
+You must be logged into a GitHub account in order to download build artifacts.
+
 ### 3. Extract the GUI AppImage/Deb
 
 Once you have the file downloaded (ex. `SlimeVR-GUI-AppImage.zip`), extract it to get a file like `slimevr-ui_0.0.0_amd64.AppImage`.


### PR DESCRIPTION
I would like someone else to verify this behavior, but I don't seem to be able to download the artifacts specified in this guide unless I am logged into my GitHub account. When I am logged out / in incognito mode, they display the names of the artifacts without any links.