### PR TITLE
components-guide-updated-alt-straps

### DIFF
--- a/src/assets/js/diy.js
+++ b/src/assets/js/diy.js
@@ -317,11 +317,11 @@
                     'links': '<a href="https://aliexpress.com/item/1005001908740631.html">AliExpress straps</a>, get some in different sizes?'
                 },
                 {
-                    'name': 'Generic Amazon straps - 6 pcs',
-                    'amount': (set) => ((set < 6) ? 1 : 2),
-                    'cost': 9.89,
-                    'costAll': (set) => ((set < 6) ? 1 : 2) * 9.89,
-                    'links': '<a href="https://www.amazon.com/dp/B091J4TWVX/">Amazon straps</a>'
+                    'name': 'Generic Amazon straps - 5 pcs',
+                    'amount': (set) => ((set < 5) ? 1 : 2),
+                    'cost': 9.00,
+                    'costAll': (set) => ((set < 5) ? 1 : 2) * 9.00,
+                    'links': '<a href="https://www.amazon.com/dp/B09T5YDMTR">Amazon straps</a>'
                 }
             ]
         },


### PR DESCRIPTION
Previous alt (Amazon) straps were too short for anything other than ankles/elbows for the Components Guide.