### PR TITLE
update calibration instructions to include sfusion imus

### DIFF
--- a/src/server/imu-calibration.md
+++ b/src/server/imu-calibration.md
@@ -2,7 +2,7 @@
 
  Make sure that when you turn on your tracker it's lying on a flat surface. The sensors need to calibrate for 20-30 seconds in a stable environment. This should be done every time you turn on your trackers, failing to do so will result in an increased rate of drift.
 
-If you have a BMI160, BMI270, MPU9250, MPU+QMC5883L, LSM6DSO or LSM6DSV-based tracker you need to calibrate the IMU before it will work correctly. This calibration only needs to be done once. You can only calibrate one IMU at a time, so if you have any extensions, they will also need to be calibrated.
+If you have a BMI160, BMI270, MPU9250, MPU+QMC5883L, LSM6DSO, or LSM6DSV-based tracker you need to calibrate the IMU before it will work correctly. This calibration only needs to be done once. You can only calibrate one IMU at a time, so if you have any extensions, they will also need to be calibrated.
 
 Other IMUs, such as the BNO085 or ICM20948 do not require any specific manual calibration and can be used immediately.
 

--- a/src/server/imu-calibration.md
+++ b/src/server/imu-calibration.md
@@ -14,9 +14,9 @@ Other IMUs, such as the BNO085 or ICM20948 do not require any specific manual ca
 1. Upon flipping the IMU over, calibration should begin. To successfully calibrate your IMU you need to gently rotate the IMU in all 3 axes.
 1. After approximately 60 seconds has passed, the tracker should be successfully calibrated and will begin to show rotation in the SlimeVR server.
 
-## BMI160 with firmware v0.3.3 and above, BMI270, LSM, or other sfusion sensors with SlimeVR/main
+## BMI160 with firmware v0.3.3 and above, BMI270, LSM6DSO and LSM6DSV
 
-If you have a BMI160 and firmware v0.3.3 or higher, or you are using BMI270, LSM6DSO, LSM6DSV or other sfusion IMUs on SlimeVR/Main or sfusion-tuned-mbe you will need to calibrate your IMU in a different way, unless specified otherwise in the firmware:
+If you have a BMI160 and firmware v0.3.3 or higher, or you are using BMI270, LSM6DSO, LSM6DSV or other sfusion IMUs you will need to calibrate your IMU in a different way, unless specified otherwise in the firmware:
 1. To get the best possible calibration, it is advisable to heat your trackers to their normal operating temperature. To do this, put on your trackers for at least 20 minutes before starting calibration.
 1. To get additional feedback on the calibration process, you can connect to the serial console. This is entirely optional.
    * Plug in your microcontroller (D1 Mini, NodeMCU, or other)

--- a/src/server/imu-calibration.md
+++ b/src/server/imu-calibration.md
@@ -1,6 +1,6 @@
 # IMU Calibration
 
- Make sure that when you turn on your tracker it's lying on a flat surface. The sensors need to calibrate for 20-30 seconds in a stable environment. This should be done every time you turn on your trackers, failing to do so will result in an increased rate of drift.
+Make sure that when you turn on your tracker it's lying on a flat surface. The sensors need to calibrate for 20-30 seconds in a stable environment. This should be done every time you turn on your trackers, failing to do so will result in an increased rate of drift.
 
 If you have a BMI160, BMI270, MPU9250, MPU+QMC5883L, LSM6DSO, or LSM6DSV-based tracker you need to calibrate the IMU before it will work correctly. This calibration only needs to be done once. You can only calibrate one IMU at a time, so if you have any extensions, they will also need to be calibrated.
 

--- a/src/server/imu-calibration.md
+++ b/src/server/imu-calibration.md
@@ -14,7 +14,7 @@ Other IMUs, such as the BNO085 or ICM20948 do not require any specific manual ca
 1. Upon flipping the IMU over, calibration should begin. To successfully calibrate your IMU you need to gently rotate the IMU in all 3 axes.
 1. After approximately 60 seconds has passed, the tracker should be successfully calibrated and will begin to show rotation in the SlimeVR server.
 
-## BMI160 with firmware v0.3.3 and above, BMI270, LSM or other sfusion sensors with SlimeVR/main
+## BMI160 with firmware v0.3.3 and above, BMI270, LSM, or other sfusion sensors with SlimeVR/main
 
 If you have a BMI160 and firmware v0.3.3 or higher, or you are using BMI270, LSM6DSO, LSM6DSV or other sfusion IMUs on SlimeVR/Main or sfusion-tuned-mbe you will need to calibrate your IMU in a different way, unless specified otherwise in the firmware:
 1. To get the best possible calibration, it is advisable to heat your trackers to their normal operating temperature. To do this, put on your trackers for at least 20 minutes before starting calibration.

--- a/src/server/imu-calibration.md
+++ b/src/server/imu-calibration.md
@@ -1,8 +1,8 @@
 # IMU Calibration
 
-If you have BNO085, MPU6050, or MPU6500-based trackers, make sure that when you turn on your tracker it's lying on a flat surface. The sensors need to calibrate for 20-30 seconds in a stable environment. This should be done every time you turn on your trackers, failing to do so will result in an increased rate of drift.
+ Make sure that when you turn on your tracker it's lying on a flat surface. The sensors need to calibrate for 20-30 seconds in a stable environment. This should be done every time you turn on your trackers, failing to do so will result in an increased rate of drift.
 
-If you have a BMI160, BMI270, MPU9250, or MPU+QMC5883L-based tracker you need to calibrate the IMU before it will work correctly. This calibration only needs to be done once. You can only calibrate one IMU at a time, so if you have any extensions, they will also need to be calibrated.
+If you have a BMI160, BMI270, MPU9250, MPU+QMC5883L, LSM6DSO or LSM6DSV-based tracker you need to calibrate the IMU before it will work correctly. This calibration only needs to be done once. You can only calibrate one IMU at a time, so if you have any extensions, they will also need to be calibrated.
 
 Other IMUs, such as the BNO085 or ICM20948 do not require any specific manual calibration and can be used immediately.
 
@@ -14,15 +14,15 @@ Other IMUs, such as the BNO085 or ICM20948 do not require any specific manual ca
 1. Upon flipping the IMU over, calibration should begin. To successfully calibrate your IMU you need to gently rotate the IMU in all 3 axes.
 1. After approximately 60 seconds has passed, the tracker should be successfully calibrated and will begin to show rotation in the SlimeVR server.
 
-## BMI160 with firmware v0.3.3 and above
+## BMI160 with firmware v0.3.3 and above, BMI270, LSM or other sfusion sensors with SlimeVR/main
 
-If you have a BMI160 and firmware v0.3.3 or higher, you will need to calibrate your IMU in a different way, unless specified otherwise in the firmware:
+If you have a BMI160 and firmware v0.3.3 or higher, or you are using BMI270, LSM6DSO, LSM6DSV or other sfusion imus on SlimeVR/Main or sfusion-tuned-mbe you will need to calibrate your IMU in a different way, unless specified otherwise in the firmware:
 1. To get the best possible calibration, it is advisable to heat your trackers to their normal operating temperature. To do this, put on your trackers for at least 20 minutes before starting calibration.
 1. To get additional feedback on the calibration process, you can connect to the serial console. This is entirely optional.
    * Plug in your microcontroller (D1 Mini, NodeMCU, or other)
    * Open the SlimeVR server, and click **Settings**, and then click **Serial Console** under **Utilities**.
 1. Flip the IMU you want to calibrate upside down and press the reset button on your microcontroller or the reboot button in the SlimeVR server. You should see a message indicating that you need to flip the IMU right side up to begin calibration.
-1. Upon flipping the IMU over, calibration should begin. Leave the IMU still for at least 10 seconds.
+1. Upon flipping the IMU over, calibration should begin. Leave the IMU still for at least 15 seconds.
 1. Now, set the IMU on a flat surface on each of the remaining 5 sides, waiting until the serial console or led indicates that you can change position for each side.
 1. The IMU should now be calibrated and will begin to show rotation in the SlimeVR server.
 
@@ -40,7 +40,3 @@ The tracker can be moved around during temperature calibration, but it will not 
 
 It may be difficult to determine how the calibration process is going. Setting `#define BMI160_TEMPCAL_DEBUG` to true in the `defines_bmi160.h` file in the firmware exposes more information about the process, replacing the regular temperature readout with temperature calibration debug info in the SlimeVR Server.
 The format is AXXYY, where A is calibration status (1 - not in calibration mode, 2 - calibration in progress), XX represents calibration progress from 0 to 60, and YY is the temperature. A fully temperature calibrated tracker would show up as 160YY.
-
-## BMI270 with firmware SlimeVR/main
-
-If you have a BMI270 tracker with SlimeVR/main firmware, you will need to calibrate your IMU the same way as you would calibrate a [BMI160 tracker with firmware v0.3.3 and above](#bmi160-with-firmware-v033-and-above).

--- a/src/server/imu-calibration.md
+++ b/src/server/imu-calibration.md
@@ -16,7 +16,7 @@ Other IMUs, such as the BNO085 or ICM20948 do not require any specific manual ca
 
 ## BMI160 with firmware v0.3.3 and above, BMI270, LSM or other sfusion sensors with SlimeVR/main
 
-If you have a BMI160 and firmware v0.3.3 or higher, or you are using BMI270, LSM6DSO, LSM6DSV or other sfusion imus on SlimeVR/Main or sfusion-tuned-mbe you will need to calibrate your IMU in a different way, unless specified otherwise in the firmware:
+If you have a BMI160 and firmware v0.3.3 or higher, or you are using BMI270, LSM6DSO, LSM6DSV or other sfusion IMUs on SlimeVR/Main or sfusion-tuned-mbe you will need to calibrate your IMU in a different way, unless specified otherwise in the firmware:
 1. To get the best possible calibration, it is advisable to heat your trackers to their normal operating temperature. To do this, put on your trackers for at least 20 minutes before starting calibration.
 1. To get additional feedback on the calibration process, you can connect to the serial console. This is entirely optional.
    * Plug in your microcontroller (D1 Mini, NodeMCU, or other)

--- a/src/server/imu-calibration.md
+++ b/src/server/imu-calibration.md
@@ -2,9 +2,10 @@
 
 Make sure that when you turn on your tracker it's lying on a flat surface. The sensors need to calibrate for 20-30 seconds in a stable environment. This should be done every time you turn on your trackers, failing to do so will result in an increased rate of drift.
 
-If you have a BMI160, BMI270, MPU9250, MPU+QMC5883L, LSM6DSO, or LSM6DSV-based tracker you need to calibrate the IMU before it will work correctly. This calibration only needs to be done once. You can only calibrate one IMU at a time, so if you have any extensions, they will also need to be calibrated.
+Some IMUs, such as the BNO085 or ICM20948 do not require any specific manual calibration and can be used immediately after letting them rest.
 
-Other IMUs, such as the BNO085 or ICM20948 do not require any specific manual calibration and can be used immediately.
+Every other IMU will need to be calibrated in order for it to work properly. This calibration only needs to be done once. You can only calibrate one IMU at a time, so if you have any extensions, they will also need to be calibrated. Please note that when using extensions, calibration data is saved onto the main tracker, so swapping extensions between main trackers will require recalibration.
+
 
 ## BMI160 with firmware v0.3.2 and below, MPU9250, or MPU+QMC5883L
 
@@ -14,7 +15,7 @@ Other IMUs, such as the BNO085 or ICM20948 do not require any specific manual ca
 1. Upon flipping the IMU over, calibration should begin. To successfully calibrate your IMU you need to gently rotate the IMU in all 3 axes.
 1. After approximately 60 seconds has passed, the tracker should be successfully calibrated and will begin to show rotation in the SlimeVR server.
 
-## BMI160 with firmware v0.3.3 and above, BMI270, LSM6DSO and LSM6DSV
+## BMI160 with firmware v0.3.3 and above, BMI270, LSM6DSO and LSM6DSV or other sfusion IMUs
 
 If you have a BMI160 and firmware v0.3.3 or higher, or you are using BMI270, LSM6DSO, LSM6DSV or other sfusion IMUs you will need to calibrate your IMU in a different way, unless specified otherwise in the firmware:
 1. To get the best possible calibration, it is advisable to heat your trackers to their normal operating temperature. To do this, put on your trackers for at least 20 minutes before starting calibration.


### PR DESCRIPTION
I clarified that other imus like bmi270 or lsm need 6 side too, and i removed the setting down part being specific to bno or mpu, since every other imu i know of benefits from it as well.