### PR TITLE
Add Quest Pro help, netsh help, and update owoTrack info

### DIFF
--- a/src/common-issues.md
+++ b/src/common-issues.md
@@ -191,6 +191,13 @@ You can easily determine the type of chip you have using Device Manager. Open De
 - CH340: "USB-SERIAL CH340"
 - FT232: "USB Serial Converter"
 
+## Quest Pro controllers cause high latency / lag
+
+Quest Pro controllers can use 2.4 GHz Wi-Fi to connect to your headset, this can cause interference with SlimeVR trackers since they also use 2.4 GHz Wi-Fi. The easiest current solution is to change the channel that your 2.4 GHz Wi-Fi is on, though this may not always work. If you want to find the Quest Pro controller's Wi-Fi, it should be called something like "DIRECT-Meta-XXXX". You can read the [Meta support article for Wi-Fi troubleshooting for the Quest Pro controllers](https://www.meta.com/help/quest/articles/getting-started/getting-started-with-quest-pro/wi-fi-troubleshooting-touch-pro-controllers/) for more information.
+
+## SlimeVR GUI keeps timing out / "Connection lost to the server. Trying to reconnect..." repeatedly
+
+If your SlimeVR GUI is repeatedly timing out from the SlimeVR server (check the logs), you may be able to fix this by running the following command in an administrator console: `netsh int tcp set supplemental internet congestionprovider=default`. This is caused by non-default Windows network configurations commonly used by modified OSes.
 
 ## References
 

--- a/src/tools/owoTrack.md
+++ b/src/tools/owoTrack.md
@@ -34,11 +34,9 @@ You can't. You will have a bad time, and that's not our fault. Your knees won't 
 
 ​You can use the official owoTrack driver for waist or SlimeVR Server for waist (+ chest if you have 2 phones). This will not track your legs.
 
-### I try to run SlimeVR Server by clicking run.bat but nothing happens. Why?
+### I try to run SlimeVR but nothing happens. Why?
 
-​You need to install Java in order to run SlimeVR Server. To download Java installer, visit [Java download page](https://www.java.com/en/download/manual.jsp).
-
-​For more information, refer to [SlimeVR setup guide](../server/index.html).
+Refer to the [SlimeVR setup guide](../server/index.html) for how to set up SlimeVR.
 
 ### My trackers are connected to the SlimeVR Server, but they are not moving in SteamVR
 
@@ -66,7 +64,7 @@ The order does not matter.
 
 ​**You can input 255.255.255.255 as IP to owoTrack Android app**
 
-To check your IP address, you can open the Powershell window or Command Prompt window (cmd.exe) and execute `ipconfig` command and get your PC IPv4 address field - for example 192.168.1.2 and put it in owoTrack app.
+To check your IP address, you can open the PowerShell window or Command Prompt window (cmd.exe) and execute `ipconfig` command and get your PC IPv4 address field - for example 192.168.1.2 and put it in owoTrack app.
 
 ### I have an iPhone and it disconnects after 10 minutes
 


### PR DESCRIPTION
- Quest Pro controllers use WiFi and can commonly interfere with 2.4 GHz WiFi that SlimeVR uses
- Modified OSes sometimes mess with the network settings and you need to just run that command and it'll fix it right up
- owoTrack tells you to install Oracle Java 8 for run.bat, what frickin' year is it??? 💀