### PR TITLE
Remove description if not set

### DIFF
--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -22,7 +22,10 @@
         <!-- Custom HTML head -->
         {{> head}}
 
+        {{#if description }}
         <meta name="description" content="{{ description }}">
+        {{/if}}
+
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="theme-color" content="#ffffff">
 


### PR DESCRIPTION
Preventing empty description tag from being sent
![image](https://github.com/user-attachments/assets/5e192440-43e8-4888-8a84-fe0897b3cb38)

