### PR TITLE
SlimeVR terminology page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -10,6 +10,7 @@
 - [SlimeVR Experience Survey](misc/survey.md)
 - [Safety Guide](safety-guides.md)
 - [Updating Your Tracker's Firmware](updating-firmware.md)
+- [SlimeVR Terminology](glossary.md)
 
 # DIY Builders Guide
 

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -9,7 +9,7 @@
 - [Yaw reset](#yaw-reset)
 - [Mounting reset](#mounting-reset)
 - [Mounting orientation](#mounting-orientation)
-- [VR headest](#vr-headset)
+- [VR headset](#vr-headset)
 
 ## SlimeVR server
 
@@ -64,7 +64,7 @@ It is a common misconception that the feeder app also forwards the [VR headset](
 
 ## Session calibration
 
-There are multiple different session calibrations within the SlimeVR Server, these are commonly referred to as "resets". These are forms of calibration that are generally not saved and need to be done during each session of SlimeVR. See the [sub-terms](#session-calibration-sub-terms) for the types of session calibrations.
+There are multiple different session calibrations within the SlimeVR Server; these are commonly referred to as "resets". These are forms of calibration that are generally not saved and need to be done during each session of SlimeVR. See the [sub-terms](#session-calibration-sub-terms) for the types of session calibrations.
 
 ### Synonyms {#session-calibration-synonyms}
 

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -1,0 +1,17 @@
+# Glossary
+
+## Resets
+
+There are multiple different "resets" within the software. These are forms of calibration that are generally not saved and need to be done during each session of SlimeVR.
+
+### Full reset
+
+A "full reset" is a [reset](#resets) that re-orients trackers to have zero rotation in the pitch and roll axes and have the same yaw axis rotation as the head tracker, essentially "resetting" (or "zeroing") the "full" orientation. This is usually the first calibration used when starting a session with SlimeVR.
+
+### Yaw reset
+
+A "yaw reset" is a [reset](#resets) that re-orients trackers to have the same yaw axis rotation as the head tracker. Since this only calibrates the yaw axis, the user can be in any position where the trackers are all facing in their forward orientation with the head tracker. This is a calibration mainly used to correct for drift after a subjective amount of time since the last yaw reset or [full reset](#full-reset).
+
+### Mounting reset
+
+A "mounting reset" (or "reset mounting") is a [reset](#resets) that corrects the base orientation of trackers in regards to their physical mounting orientation. This is usually the second calibration used when starting a session with SlimeVR if the user chooses to use automatic mounting.

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -64,7 +64,7 @@ It is a common misconception that the feeder app also forwards the [VR headset](
 
 ## Session calibration
 
-There are multiple different session calibrations within the SlimeVR Server. These are forms of calibration that are generally not saved and need to be done during each session of SlimeVR. See the [sub-terms](#session-calibration-sub-terms) for the types of session calibrations.
+There are multiple different session calibrations within the SlimeVR Server, these are commonly referred to as "resets". These are forms of calibration that are generally not saved and need to be done during each session of SlimeVR. See the [sub-terms](#session-calibration-sub-terms) for the types of session calibrations.
 
 ### Synonyms {#session-calibration-synonyms}
 

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -1,17 +1,131 @@
-# Glossary
+# SlimeVR Terminology / Glossary
 
-## Resets
+- [SlimeVR server](#slimevr-server)
+- [SlimeVR GUI](#slimevr-gui)
+- [SteamVR driver](#steamvr-driver)
+- [Feeder app](#feeder-app)
+- [Session calibration](#session-calibration)
+- [Full reset](#full-reset)
+- [Yaw reset](#yaw-reset)
+- [Mounting reset](#mounting-reset)
+- [Mounting orientation](#mounting-orientation)
+- [VR headest](#vr-headset)
 
-There are multiple different "resets" within the software. These are forms of calibration that are generally not saved and need to be done during each session of SlimeVR.
+## SlimeVR server
 
-### Full reset
+The main SlimeVR application for receiving, processing, and outputting tracking data. This application runs locally using Java and connects to the [SlimeVR GUI](#slimevr-gui) for a visual interface.
 
-A "full reset" is a [reset](#resets) that re-orients trackers to have zero rotation in the pitch and roll axes and have the same yaw axis rotation as the head tracker, essentially "resetting" (or "zeroing") the "full" orientation. This is usually the first calibration used when starting a session with SlimeVR.
+### Synonyms {#slimevr-server-synonyms}
 
-### Yaw reset
+- SlimeVR (contextual)
+- SlimeVR app
+- SlimeVR software
+- SlimeVR program
 
-A "yaw reset" is a [reset](#resets) that re-orients trackers to have the same yaw axis rotation as the head tracker. Since this only calibrates the yaw axis, the user can be in any position where the trackers are all facing in their forward orientation with the head tracker. This is a calibration mainly used to correct for drift after a subjective amount of time since the last yaw reset or [full reset](#full-reset).
+### Related terms {#slimevr-server-related}
 
-### Mounting reset
+- [SlimeVR GUI](#slimevr-gui)
+- [SteamVR driver](#steamvr-driver)
 
-A "mounting reset" (or "reset mounting") is a [reset](#resets) that corrects the base orientation of trackers in regards to their physical mounting orientation. This is usually the second calibration used when starting a session with SlimeVR if the user chooses to use automatic mounting.
+## SlimeVR GUI
+
+The visual interface for the [SlimeVR server](#slimevr-server). This GUI runs as a webview and connects to the [SlimeVR server](#slimevr-server) over a websocket connection.
+
+### Related terms {#slimevr-gui-related}
+
+- [SlimeVR server](#slimevr-server)
+
+## SteamVR driver
+
+The SlimeVR driver for SteamVR that sends the [VR headset](#vr-headset) position and rotation to the [SlimeVR server](#slimevr-server), receives tracking data from the [SlimeVR server](#slimevr-server), and uses the received tracking data to emulate Vive trackers in SteamVR.
+
+### Synonyms {#steamvr-driver-synonyms}
+
+- SlimeVR driver
+
+### Related terms {#steamvr-driver-related}
+
+- [SlimeVR server](#slimevr-server)
+
+## Feeder app
+
+The feeder app is a program that connects to SteamVR and forwards tracker data from external sources to the [SlimeVR server](#slimevr-server). The trackers forwarded are generally VR controllers, Vive trackers, or Tundra trackers.
+
+It is a common misconception that the feeder app also forwards the [VR headset](#vr-headset) tracking data, but that is done by the [SteamVR driver](#steamvr-driver).
+
+### Synonyms {#feeder-app-synonyms}
+
+- SlimeVR feeder
+- Feeder
+
+### Related terms {#feeder-app-related}
+
+- [SlimeVR server](#slimevr-server)
+
+## Session calibration
+
+There are multiple different session calibrations within the SlimeVR Server. These are forms of calibration that are generally not saved and need to be done during each session of SlimeVR. See the [sub-terms](#session-calibration-sub-terms) for the types of session calibrations.
+
+### Synonyms {#session-calibration-synonyms}
+
+- Resets
+- Software calibration
+- VR calibration
+
+### Sub-terms {#session-calibration-sub}
+
+- [Full reset](#full-reset)
+- [Yaw reset](#yaw-reset)
+- [Mounting reset](#mounting-reset)
+
+## Full reset
+
+A "full reset" is a [session calibration](#session-calibration) that re-orients trackers to have zero rotation in the pitch and roll axes and have the same yaw axis rotation as the head tracker (usually a [VR headset](#vr-headset)), essentially "resetting" (or "zeroing") the "full" orientation. This is usually the first calibration used when starting a session with SlimeVR.
+
+## Yaw reset
+
+A "yaw reset" is a [session calibration](#session-calibration) that re-orients trackers to have the same yaw axis rotation as the head tracker (usually a [VR headset](#vr-headset)). Since this only calibrates the yaw axis, the user can be in any position where the trackers are all facing in their forward orientation with the head tracker. This is a calibration mainly used to correct for drift after a subjective amount of time since the last yaw reset or [full reset](#full-reset).
+
+### Synonyms {#yaw-reset-synonyms}
+
+- Fast reset
+- Quick reset
+
+## Mounting reset
+
+A "mounting reset" (or "reset mounting") is a [session calibration](#session-calibration) that corrects the base orientation of trackers in regards to how they are physically mounted to your body. This is usually the second calibration used when starting a session with SlimeVR if the user chooses to use automatic mounting. When mounting reset is used, the results of the calibration will override any manually set [mounting orientation](#mounting-orientation).
+
+### Synonyms {#mounting-reset-synonyms}
+
+- Reset mounting
+- Mounting calibration
+- Automatic mounting
+- Automatic mounting orientation
+
+### Related terms {#mounting-reset-related}
+
+- [Mounting orientation](#mounting-orientation)
+
+## Mounting orientation
+
+Mounting orientation is a type of correction for SlimeVR trackers. Mounting orientation corrects the base orientation of trackers in regards to how they are physically mounted to your body.
+
+### Synonyms {#mounting-orientation-synonyms}
+
+- Mounting direction
+- Manual mounting
+
+### Related terms {#mounting-orientation-related}
+
+- [Mounting reset](#mounting-reset)
+
+## VR headset
+
+A VR headset is a head mounted device that tracks its position and rotation, usually with a display for each eye. For more information, see <https://wikipedia.org/wiki/Virtual_reality_headset>.
+
+### Synonyms {#vr-headset-synonyms}
+
+- Virtual reality headset
+- HMD
+- Head mounted device
+- Headset


### PR DESCRIPTION
Super cool SlimeVR glossary that provides base definitions for most SlimeVR related terms with some relevant info, like misconceptions and where to find more information regarding a specific term. This is meant to be brief, direct, and low maintenance. Further explanation and description of terms can be done on their relevant sections in the docs and can be linked where appropriate.

This glossary should be really helpful for newcomers to the SlimeVR space, where they have no idea what a "SlimeVR server" or "Yaw reset" is.