### PR TITLE
Fix malformed HTML in BNO085 link

### DIFF
--- a/src/assets/js/diy.js
+++ b/src/assets/js/diy.js
@@ -23,7 +23,7 @@
                     'amount': (set) => set,
                     'cost': 11,
                     'costAll': (set) => set * 11 + 6,
-                    'links': '<a href="https://shop.slimevr.dev/products/slimevr-imu-module-bno085" target="_blank">Official SlimeVR BNO085</a> or <a href="https://www.mouser.com/c/?q=BNO085" target="_blank>Adafruit BNO085</a>.'
+                    'links': '<a href="https://shop.slimevr.dev/products/slimevr-imu-module-bno085" target="_blank">Official SlimeVR BNO085</a> or <a href="https://www.mouser.com/c/?q=BNO085" target="_blank">Adafruit BNO085</a>.'
                 },
                 {
                     'name': 'LSM6DSV',


### PR DESCRIPTION
![before](https://github.com/user-attachments/assets/d168c996-9031-4d96-b7eb-0091ff264580)
Just a typo fix to make the Adafruit BNO085 link visible again in the cost calculator
![after](https://github.com/user-attachments/assets/9b2f16be-8d72-4c85-9dc8-2dab48f110ba)
