### PR TITLE
Made small resolution cards display cells inline

### DIFF
--- a/src/slimevr101.css
+++ b/src/slimevr101.css
@@ -29,13 +29,12 @@
   }
 
   tbody td:not(:first-child)::before {
-    content: attr(data-label);
+    content: attr(data-label) ' ';
     font-weight: bold;
-    text-align: left;
-    padding-right: 1rem;
+    display: contents;
   }
 
   tbody td:last-child {
-    padding: 2rem 10px 1rem 10px;
+    padding: 10px 20px;
   }
 }


### PR DESCRIPTION
Now:
![image](https://github.com/user-attachments/assets/3f4d67b4-f0ed-495a-9d38-53adb5969ffa)
With this change:
![image](https://github.com/user-attachments/assets/5fa580f1-b4d3-46b2-bf08-822684f99f2f)

(Difference in colors comes from different themes used on different screenshots)