### PR TITLE
Smols pages responsive scaling fixes for smaller resolutions

### DIFF
--- a/src/diy/smol-slimes/smol-hardware.md
+++ b/src/diy/smol-slimes/smol-hardware.md
@@ -23,85 +23,112 @@ To ensure optimal signal integrity and range, it is essential to use boards equi
 
 These dongles are equipped with relatively well-optimized PCB antennas. For improved signal integrity, especially in constrained environments, consider using a USB extension cable.
 
-<table>
-  <thead>
-    <tr>
-      <th>Dongle</th>
-      <th>Description</th>
-      <th>Links</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <span id="eByteDongle">
-          eByte Dongle (E104-BT5040U)
-        </span>
-      </td>
-      <td>
-        Cheapest option with a PCB antenna.<br />
-        - <strong>E104-BT5040U</strong> is the correct model to use. It is fully
-        compatible with the Nordic Semiconductor nRF52840 Dongle.<br />
-        - <strong>E104-BT5040UA</strong> is not compatible. It is only capable
-        of capturing BLE4.2 and BLE5.0 protocol packets.
-      </td>
-      <td>
-        <ul>
-          <li>
-            <a href="https://www.nordicsemi.com/Products/Development-hardware/nRF52840-Dongle">Manufacturer page</a>
-          </li>
-          <li>
-            <a href="https://www.alibaba.com/product-detail/Ebyte-ODM-E104-BT5040U-nRF52840-BLE4_1600579144016.html?spm=a2756.trade-list-buyer.0.0.535476e9B4p1qV">Alibaba</a>
-          </li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <span id="NordicDongle">
-          Nordic Semiconductor nRF52840 Dongle (PCA10059)
-        </span>
-      </td>
-      <td>Official Nordic development hardware.</td>
-      <td>
-        <ul>
-          <li>
-            <a href="https://www.cdebyte.com/products/E104-BT5040U">Manufacturer page</a>
-          </li>
-          <li>
-            <a href="https://www.digikey.com/en/products/detail/nordic-semiconductor-asa/NRF52840-DONGLE/9491124">Digikey</a>
-          </li>
-          <li>
-            <a href="https://eu.mouser.com/ProductDetail/Nordic-Semiconductor/nRF52840-Dongle?qs=gTYE2QTfZfTbdrOaMHWEZg%3D%3D">Mouser</a>
-          </li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <span id="HolyIOT">
-          HolyIOT-21017 aka HOLYIOT-21017-nRF52840
-        </span>
-      </td>
-      <td>
-        Has a FEM (Front End Module), specifically an <strong>RFX2401C</strong> radio booster.
-      </td>
-      <td>
-        <ul>
-          <li>
-            <a href="http://www.holyiot.com/eacp_view.asp?id=336">Manufacturer page</a>
-          </li>
-          <li>
-            <a href="https://www.aliexpress.com/item/1005004673179004.html">AliExpress</a>
-          </li>
-          <li>
-            <a href="https://holyiot.en.alibaba.com/search/product?SearchText=HOLYIOT-21017-nRF52840">Alibaba</a>
-          </li>
-        </ul>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<div class="table-wrapper">
+    <table>
+        <thead>
+            <tr>
+                <th>Dongle</th>
+                <th>Description</th>
+                <th>Links</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>
+                    <span id="eByteDongle"> eByte Dongle (E104-BT5040U) </span>
+                </td>
+                <td>
+                    Cheapest option with a PCB antenna.<br />
+                    - <strong>E104-BT5040U</strong> is the correct model to use.
+                    It is fully compatible with the Nordic Semiconductor
+                    nRF52840 Dongle.<br />
+                    - <strong>E104-BT5040UA</strong> is not compatible. It is
+                    only capable of capturing BLE4.2 and BLE5.0 protocol
+                    packets.
+                </td>
+                <td>
+                    <ul>
+                        <li>
+                            <a
+                                href="https://www.nordicsemi.com/Products/Development-hardware/nRF52840-Dongle"
+                                >Manufacturer page</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                href="https://www.alibaba.com/product-detail/Ebyte-ODM-E104-BT5040U-nRF52840-BLE4_1600579144016.html?spm=a2756.trade-list-buyer.0.0.535476e9B4p1qV"
+                                >Alibaba</a
+                            >
+                        </li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <span id="NordicDongle">
+                        Nordic Semiconductor nRF52840 Dongle (PCA10059)
+                    </span>
+                </td>
+                <td>Official Nordic development hardware.</td>
+                <td>
+                    <ul>
+                        <li>
+                            <a
+                                href="https://www.cdebyte.com/products/E104-BT5040U"
+                                >Manufacturer page</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                href="https://www.digikey.com/en/products/detail/nordic-semiconductor-asa/NRF52840-DONGLE/9491124"
+                                >Digikey</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                href="https://eu.mouser.com/ProductDetail/Nordic-Semiconductor/nRF52840-Dongle?qs=gTYE2QTfZfTbdrOaMHWEZg%3D%3D"
+                                >Mouser</a
+                            >
+                        </li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <span id="HolyIOT">
+                        HolyIOT-21017 aka HOLYIOT-21017-nRF52840
+                    </span>
+                </td>
+                <td>
+                    Has a FEM (Front End Module), specifically an
+                    <strong>RFX2401C</strong> radio booster.
+                </td>
+                <td>
+                    <ul>
+                        <li>
+                            <a
+                                href="http://www.holyiot.com/eacp_view.asp?id=336"
+                                >Manufacturer page</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                href="https://www.aliexpress.com/item/1005004673179004.html"
+                                >AliExpress</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                href="https://holyiot.en.alibaba.com/search/product?SearchText=HOLYIOT-21017-nRF52840"
+                                >Alibaba</a
+                            >
+                        </li>
+                    </ul>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### 📡 Microcontrollers Modified Into USB Dongles
 
@@ -130,70 +157,74 @@ Refer to <a href="./smol-schematics.md">Smol Schematics -> Antenna extra option<
 
 ##### Components Options
 
-<table>
-  <thead>
-    <tr>
-      <th>Image</th>
-      <th>Listing</th>
-      <th>Notes</th>
-      <th>Variant</th>
-      <th>Link</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <img
-          src="assets\smol-hardware\wifi_antenna.webp"
-          loading="lazy"
-        />
-      </td>
-      <td>
-        2PCS Mini Rubber 3dBi 2.4ghz WIFI Antenna SMA Male Router Bluetooth Antennas Wireless Module 2.4g Antena External Aerial
-      </td>
-      <td>
-         Best tested performance (based on Lyall’s tests)
-      </td>
-      <td>
-        Color: B
-      </td>
-      <td>
-        <ul>
-          <li>
-            <a href="https://www.aliexpress.com/item/1005006686310444.html">AliExpress</a>
-          </li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <img
-          src="assets\smol-hardware\wifi_antenna_adapter.webp"
-          loading="lazy"
-        />
-      </td>
-      <td>
-        IPX to SMA RF Coax Adapter Assembly Pigtail Cable,SMA Connector Cable Female to UFL
-      </td>
-      <td>
-         Any IPEX or SMA cable should do.
-         <br/>
-         Cut cable at marked location on the image.
-      </td>
-      <td>
-        Shorter cables preferred.
-      </td>
-      <td>
-        <ul>
-          <li>
-            <a href="https://www.aliexpress.com/item/32896039259.html">AliExpress</a>
-          </li>
-        </ul>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
+<div class="table-wrapper">
+    <table>
+        <thead>
+            <tr>
+                <th>Image</th>
+                <th>Listing</th>
+                <th>Notes</th>
+                <th>Variant</th>
+                <th>Link</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>
+                    <img
+                        src="assets\smol-hardware\wifi_antenna.webp"
+                        loading="lazy"
+                    />
+                </td>
+                <td>
+                    2PCS Mini Rubber 3dBi 2.4ghz WIFI Antenna SMA Male Router
+                    Bluetooth Antennas Wireless Module 2.4g Antena External
+                    Aerial
+                </td>
+                <td>Best tested performance (based on Lyall’s tests)</td>
+                <td>Color: B</td>
+                <td>
+                    <ul>
+                        <li>
+                            <a
+                                href="https://www.aliexpress.com/item/1005006686310444.html"
+                                >AliExpress</a
+                            >
+                        </li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <img
+                        src="assets\smol-hardware\wifi_antenna_adapter.webp"
+                        loading="lazy"
+                    />
+                </td>
+                <td>
+                    IPX to SMA RF Coax Adapter Assembly Pigtail Cable,SMA
+                    Connector Cable Female to UFL
+                </td>
+                <td>
+                    Any IPEX or SMA cable should do.
+                    <br />
+                    Cut cable at marked location on the image.
+                </td>
+                <td>Shorter cables preferred.</td>
+                <td>
+                    <ul>
+                        <li>
+                            <a
+                                href="https://www.aliexpress.com/item/32896039259.html"
+                                >AliExpress</a
+                            >
+                        </li>
+                    </ul>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ## 🏃 Trackers
 
@@ -204,51 +235,58 @@ Buttons and slide switches are recommended but not required. Buttons can be adde
 
 ### 📻 Microcontroller Boards
 
-<table>
-  <thead>
-    <tr>
-      <th>Board</th>
-      <th>Description</th>
-      <th>Obtaining</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <span id="SuperMini">
-          SuperMini nRF52840
-        </span>
-      </td>
-      <td>
-        A clone of the <strong>nice!nano</strong> board. Cheapest option overall. 
-        <br/> Signal strength can be improved with antenna mod.
-      </td>
-      <td>
-        Available on AliExpress with <code>compatible with nice!nano</code> or <code>Pro Micro</code> branding.
-        <ul>
-          <li>
-            <a href="https://pl.aliexpress.com/item/1005007738886550.html">AliExpress TENSTAR 2pcs pack</a>
-          </li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <span id="XIAO">
-          Seeed Studio XIAO nRF52840
-        </span>
-      </td>
-      <td>Compact board.</td>
-      <td>
-        <ul>
-          <li>
-            <a href="https://www.seeedstudio.com/Seeed-XIAO-BLE-nRF52840-p-5201.html">Manufacturer listing</a>
-          </li>
-        </ul>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<div class="table-wrapper">
+    <table>
+        <thead>
+            <tr>
+                <th>Board</th>
+                <th>Description</th>
+                <th>Obtaining</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>
+                    <span id="SuperMini"> SuperMini nRF52840 </span>
+                </td>
+                <td>
+                    A clone of the <strong>nice!nano</strong> board. Cheapest
+                    option overall. <br />
+                    Signal strength can be improved with antenna mod.
+                </td>
+                <td>
+                    Available on AliExpress with
+                    <code>compatible with nice!nano</code> or
+                    <code>Pro Micro</code> branding.
+                    <ul>
+                        <li>
+                            <a
+                                href="https://pl.aliexpress.com/item/1005007738886550.html"
+                                >AliExpress TENSTAR 2pcs pack</a
+                            >
+                        </li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <span id="XIAO"> Seeed Studio XIAO nRF52840 </span>
+                </td>
+                <td>Compact board.</td>
+                <td>
+                    <ul>
+                        <li>
+                            <a
+                                href="https://www.seeedstudio.com/Seeed-XIAO-BLE-nRF52840-p-5201.html"
+                                >Manufacturer listing</a
+                            >
+                        </li>
+                    </ul>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### 🧭 Inertial Measurement Units
 
@@ -294,34 +332,41 @@ Some of the supported sensor modules are described on the [IMU Comparison page](
 
 Meia, a member of the SlimeVR Discord, produces and sells IMUs with an onboard magnetometer suitable for stacked builds.
 
-<table>
-  <thead>
-    <tr>
-      <th>IMU + Magnetometer</th>
-      <th>Product Page</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <a href="../imu-comparison.md#ICM-45686">ICM-45686</a> + IST8306
-      </td>
-      <td>
-        <a href="https://store.kouno.xyz/products/icm-45686-ist8306-module">
-          store.kouno.xyz
-        </a>
-      </td>
-    </tr>
-    <tr>
-      <td>LSM6DSR + IST8306</td>
-      <td>
-        <a href="https://store.kouno.xyz/products/lsm6dsr-ist8306-module">
-          store.kouno.xyz
-        </a>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<div class="table-wrapper">
+    <table>
+        <thead>
+            <tr>
+                <th>IMU + Magnetometer</th>
+                <th>Product Page</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>
+                    <a href="../imu-comparison.md#ICM-45686">ICM-45686</a> +
+                    IST8306
+                </td>
+                <td>
+                    <a
+                        href="https://store.kouno.xyz/products/icm-45686-ist8306-module"
+                    >
+                        store.kouno.xyz
+                    </a>
+                </td>
+            </tr>
+            <tr>
+                <td>LSM6DSR + IST8306</td>
+                <td>
+                    <a
+                        href="https://store.kouno.xyz/products/lsm6dsr-ist8306-module"
+                    >
+                        store.kouno.xyz
+                    </a>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### 🖲️ Buttons
 

--- a/src/diy/smol-slimes/smol-slimes-community-builds.md
+++ b/src/diy/smol-slimes/smol-slimes-community-builds.md
@@ -21,226 +21,226 @@ This page is dedicated only to builds that others can build themselves. Builds t
 
 ## Builds table
 
-<table class="community-builds-table table-sort table-arrows">
-  <thead>
-    <tr>
-      <th class="disable-sort">Image</th>
-      <th class="onload-sort">Name</th>
-      <th>Author</th>
-      <th>Link</th>
-      <th>USB</th>
-      <th>PCB</th>
-      <th>Battery</th>
-      <th>Dock</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="case-image" data-label="Image">
-        <img
-          src="https://raw.githubusercontent.com/Aed-1/Aed-Slimes/refs/heads/main/img/Aed-Slime.png"
-          loading="lazy"
-        />
-      </td>
-      <td class="case-name" data-label="Name">Aed-Slimes</td>
-      <td class="case-author" data-label="Author">Aed</td>
-      <td class="case-link" data-label="Link">
-        <a href="https://github.com/Aed-1/Aed-Slimes">GitHub</a>
-      </td>
-      <td class="case-usb" data-label="USB">✅</td>
-      <td class="case-pcb" data-label="PCB">✅</td>
-      <td class="case-battery" data-label="Battery">
-        <div class="tooltip-text-container">
-          120 mAh
-          <span class="tooltip-text">LIR2450 Battery</span>
-        </div>
-      </td>
-      <td class="case-dock" data-label="Dock">✖️</td>
-    </tr>
-    <tr>
-      <td class="case-image" data-label="Image">
-        <img
-          src="https://raw.githubusercontent.com/ManicQuinn/SlimeVR-Gremlin/refs/heads/main/photos/GremlinTrackers.png"
-          loading="lazy"
-        />
-      </td>
-      <td class="case-name" data-label="Name">Gremlin</td>
-      <td class="case-author" data-label="Author">ManicQuinn</td>
-      <td class="case-link" data-label="Link">
-        <a href="https://github.com/ManicQuinn/SlimeVR-Gremlin">GitHub</a>
-      </td>
-      <td class="case-usb" data-label="USB">✅</td>
-      <td class="case-pcb" data-label="PCB">✖️</td>
-      <td class="case-battery" data-label="Battery">
-        <div class="tooltip-text-container">
-          110 mAh
-          <span class="tooltip-text">401230 Battery</span>
-        </div>
-      </td>
-      <td class="case-dock" data-label="Dock">✖️</td>
-    </tr>
-    <tr>
-      <td class="case-image" data-label="Image">
-        <img
-          src="assets/Marzipan-Case-By-Colanns.png"
-          loading="lazy"
-        />
-      </td>
-      <td class="case-name" data-label="Name">Marzipan</td>
-      <td class="case-author" data-label="Author">Colanns</td>
-      <td class="case-link" data-label="Link">
-        <a href="https://github.com/colasama/Marzipan">GitHub</a>
-      </td>
-      <td class="case-usb" data-label="USB">✅</td>
-      <td class="case-pcb" data-label="PCB">✅</td>
-      <td class="case-battery" data-label="Battery" style="white-space: nowrap">
-        <div class="tooltip-text-container">
-          110 mAh
-          <span class="tooltip-text">401230 Battery</span>
-        </div>
-        /
-        <div class="tooltip-text-container">
-          170 mAh
-          <span class="tooltip-text">501230 Battery</span>
-        </div>
-      </td>
-      <td class="case-dock" data-label="Dock">✖️</td>
-    </tr>
-    <tr>
-      <td class="case-image" data-label="Image">
-        <img
-          src="assets/SlimeNRF-R1&R2-by-sctanf.jpg"
-          loading="lazy"
-        />
-      </td>
-      <td class="case-name" data-label="Name">SlimeNRF R1/R2</td>
-      <td class="case-author" data-label="Author">sctanf</td>
-      <td class="case-link" data-label="Link">
-        <a href="https://github.com/SlimeVR/SlimeVR-Tracker-nRF-PCB">GitHub</a>
-      </td>
-      <td class="case-usb" data-label="USB">✖️</td>
-      <td class="case-pcb" data-label="PCB">✅</td>
-      <td class="case-battery" data-label="Battery">
-        <div class="tooltip-text-container">
-          300 mAh
-          <span class="tooltip-text">601230 Battery</span>
-        </div>
-      </td>
-      <td class="case-dock" data-label="Dock">✅</td>
-    </tr>
-    <tr>
-      <td class="case-image" data-label="Image">
-        <img
-          src="assets/SlimeNRF-R3-by-sctanf.webp"
-          loading="lazy"
-        />
-      </td>
-      <td class="case-name" data-label="Name">SlimeNRF R3</td>
-      <td class="case-author" data-label="Author">sctanf</td>
-      <td class="case-link" data-label="Link">
-        <a href="https://oshwlab.com/sctanf/slimenrf3">Oshwlab</a>
-      </td>
-      <td class="case-usb" data-label="USB">✅</td>
-      <td class="case-pcb" data-label="PCB">✅</td>
-      <td class="case-battery" data-label="Battery" style="white-space: nowrap;">
-        <div class="tooltip-text-container">80 mAh
-          <span class="tooltip-text">301230 Battery</span>
-        </div>
-        /
-        <div class="tooltip-text-container">100 mAh
-          <span class="tooltip-text">242030 Battery</span>
-        </div>
-      </td>
-      <td class="case-dock" data-label="Dock">
-        <div class="tooltip-text-container">✅
-          <span class="tooltip-text">Use SlimeNRF R1/R2 dock.</span>
-        </div>
-      </td>
-    </tr>
-    <tr>
-      <td class="case-image" data-label="Image">
-        <img
-          src="assets/SlimeNRF-Fuimini-by-Zipra1.webp"
-          loading="lazy"
-        />
-      </td>
-      <td class="case-name" data-label="Name">SlimeNRF-Fuimini</td>
-      <td class="case-author" data-label="Author">Zipra1</td>
-      <td class="case-link" data-label="Link">
-        <a href="https://github.com/Zipra1/SlimeNRF-Fuimini">GitHub</a>
-      </td>
-      <td class="case-usb" data-label="USB">✅</td>
-      <td class="case-pcb" data-label="PCB">✅</td>
-      <td class="case-battery" data-label="Battery">100 mAh</td>
-      <td class="case-dock" data-label="Dock">✅</td>
-    </tr>
-    <tr>
-      <td class="case-image" data-label="Image">
-        <img
-          src="assets/Smol-Panini-Case-by-TigsterCox.webp"
-          loading="lazy"
-        />
-      </td>
-      <td class="case-name" data-label="Name">Smol Panini Case</td>
-      <td class="case-author" data-label="Author">TigsterCox</td>
-      <td class="case-link" data-label="Link">
-        <a href="https://github.com/TigsterCox/Smol-Panini-Case/">Github</a>
-      </td>
-      <td class="case-usb" data-label="USB">✅</td>
-      <td class="case-pcb" data-label="PCB">✖️</td>
-      <td class="case-battery" data-label="Battery">
-        <div class="tooltip-text-container">
-          180 mAh
-          <span class="tooltip-text">601230 Battery</span>
-        </div>
-      </td>
-      <td class="case-dock" data-label="Dock">✖️</td>
-    </tr>
-    <tr>
-      <td class="case-image" data-label="Image">
-        <img
-          src="assets/Ibis Trackers-by-brisfknibis.webp"
-          loading="lazy"
-        />
-      </td>
-      <td class="case-name" data-label="Name">Ibis Trackers</td>
-      <td class="case-author" data-label="Author">brisfknibis</td>
-      <td class="case-link" data-label="Link">
-        <a href="https://github.com/brisfknibis/ibis-trackers/">Github</a>
-      </td>
-      <td class="case-usb" data-label="USB">✅</td>
-      <td class="case-pcb" data-label="PCB">✖️</td>
-      <td class="case-battery" data-label="Battery">
-        <div class="tooltip-text-container">
-          100 mAh
-          <span class="tooltip-text">401030 Battery</span>
-        </div>
-      </td>
-      <td class="case-dock" data-label="Dock">✖️</td>
-    </tr>
-    <tr>
-      <td class="case-image" data-label="Image">
-        <img
-          src="assets/Stacked-SmolSlime-by-LyallUlric.png"
-          loading="lazy"
-        />
-      </td>
-      <td class="case-name" data-label="Name">Stacked SmolSlime</td>
-      <td class="case-author" data-label="Author">LyallUlric</td>
-      <td class="case-link" data-label="Link">
-        <a href="https://www.thingiverse.com/thing:6941615">Thingiverse</a>
-      </td>
-      <td class="case-usb" data-label="USB">✅</td>
-      <td class="case-pcb" data-label="PCB">✖️</td>
-      <td class="case-battery" data-label="Battery">
-        <div class="tooltip-text-container">
-          100 mAh
-          <span class="tooltip-text">401030 Battery</span>
-        </div>
-      </td>
-      <td class="case-dock" data-label="Dock">✖️</td>
-    </tr>
-  </tbody>
-</table>
+<div class="table-wrapper">
+  <table class="community-builds-table table-sort table-arrows">
+    <thead>
+      <tr>
+        <th class="disable-sort">Image</th>
+        <th class="onload-sort">Name</th>
+        <th>Author</th>
+        <th>Link</th>
+        <th>USB</th>
+        <th>PCB</th>
+        <th>Battery</th>
+        <th>Dock</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="case-image" data-label="Image">
+          <img
+            src="https://raw.githubusercontent.com/Aed-1/Aed-Slimes/refs/heads/main/img/Aed-Slime.png"
+            loading="lazy"
+          />
+        </td>
+        <td class="case-name" data-label="Name">Aed-Slimes</td>
+        <td class="case-author" data-label="Author">Aed</td>
+        <td class="case-link" data-label="Link">
+          <a href="https://github.com/Aed-1/Aed-Slimes">GitHub</a>
+        </td>
+        <td class="case-usb" data-label="USB">✅</td>
+        <td class="case-pcb" data-label="PCB">✅</td>
+        <td class="case-battery" data-label="Battery">
+          <div class="tooltip-text-container">
+            120 mAh
+            <span class="tooltip-text">LIR2450 Battery</span>
+          </div>
+        </td>
+        <td class="case-dock" data-label="Dock">✖️</td>
+      </tr>
+      <tr>
+        <td class="case-image" data-label="Image">
+          <img
+            src="https://raw.githubusercontent.com/ManicQuinn/SlimeVR-Gremlin/refs/heads/main/photos/GremlinTrackers.png"
+            loading="lazy"
+          />
+        </td>
+        <td class="case-name" data-label="Name">Gremlin</td>
+        <td class="case-author" data-label="Author">ManicQuinn</td>
+        <td class="case-link" data-label="Link">
+          <a href="https://github.com/ManicQuinn/SlimeVR-Gremlin">GitHub</a>
+        </td>
+        <td class="case-usb" data-label="USB">✅</td>
+        <td class="case-pcb" data-label="PCB">✖️</td>
+        <td class="case-battery" data-label="Battery">
+          <div class="tooltip-text-container">
+            110 mAh
+            <span class="tooltip-text">401230 Battery</span>
+          </div>
+        </td>
+        <td class="case-dock" data-label="Dock">✖️</td>
+      </tr>
+      <tr>
+        <td class="case-image" data-label="Image">
+          <img src="assets/Marzipan-Case-By-Colanns.png" loading="lazy" />
+        </td>
+        <td class="case-name" data-label="Name">Marzipan</td>
+        <td class="case-author" data-label="Author">Colanns</td>
+        <td class="case-link" data-label="Link">
+          <a href="https://github.com/colasama/Marzipan">GitHub</a>
+        </td>
+        <td class="case-usb" data-label="USB">✅</td>
+        <td class="case-pcb" data-label="PCB">✅</td>
+        <td
+          class="case-battery"
+          data-label="Battery"
+          style="white-space: nowrap"
+        >
+          <div class="tooltip-text-container">
+            110 mAh
+            <span class="tooltip-text">401230 Battery</span>
+          </div>
+          /
+          <div class="tooltip-text-container">
+            170 mAh
+            <span class="tooltip-text">501230 Battery</span>
+          </div>
+        </td>
+        <td class="case-dock" data-label="Dock">✖️</td>
+      </tr>
+      <tr>
+        <td class="case-image" data-label="Image">
+          <img src="assets/SlimeNRF-R1&R2-by-sctanf.jpg" loading="lazy" />
+        </td>
+        <td class="case-name" data-label="Name">SlimeNRF R1/R2</td>
+        <td class="case-author" data-label="Author">sctanf</td>
+        <td class="case-link" data-label="Link">
+          <a href="https://github.com/SlimeVR/SlimeVR-Tracker-nRF-PCB"
+            >GitHub</a
+          >
+        </td>
+        <td class="case-usb" data-label="USB">✖️</td>
+        <td class="case-pcb" data-label="PCB">✅</td>
+        <td class="case-battery" data-label="Battery">
+          <div class="tooltip-text-container">
+            300 mAh
+            <span class="tooltip-text">601230 Battery</span>
+          </div>
+        </td>
+        <td class="case-dock" data-label="Dock">✅</td>
+      </tr>
+      <tr>
+        <td class="case-image" data-label="Image">
+          <img src="assets/SlimeNRF-R3-by-sctanf.webp" loading="lazy" />
+        </td>
+        <td class="case-name" data-label="Name">SlimeNRF R3</td>
+        <td class="case-author" data-label="Author">sctanf</td>
+        <td class="case-link" data-label="Link">
+          <a href="https://oshwlab.com/sctanf/slimenrf3">Oshwlab</a>
+        </td>
+        <td class="case-usb" data-label="USB">✅</td>
+        <td class="case-pcb" data-label="PCB">✅</td>
+        <td
+          class="case-battery"
+          data-label="Battery"
+          style="white-space: nowrap"
+        >
+          <div class="tooltip-text-container">
+            80 mAh
+            <span class="tooltip-text">301230 Battery</span>
+          </div>
+          /
+          <div class="tooltip-text-container">
+            100 mAh
+            <span class="tooltip-text">242030 Battery</span>
+          </div>
+        </td>
+        <td class="case-dock" data-label="Dock">
+          <div class="tooltip-text-container">
+            ✅
+            <span class="tooltip-text">Use SlimeNRF R1/R2 dock.</span>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td class="case-image" data-label="Image">
+          <img src="assets/SlimeNRF-Fuimini-by-Zipra1.webp" loading="lazy" />
+        </td>
+        <td class="case-name" data-label="Name">SlimeNRF-Fuimini</td>
+        <td class="case-author" data-label="Author">Zipra1</td>
+        <td class="case-link" data-label="Link">
+          <a href="https://github.com/Zipra1/SlimeNRF-Fuimini">GitHub</a>
+        </td>
+        <td class="case-usb" data-label="USB">✅</td>
+        <td class="case-pcb" data-label="PCB">✅</td>
+        <td class="case-battery" data-label="Battery">100 mAh</td>
+        <td class="case-dock" data-label="Dock">✅</td>
+      </tr>
+      <tr>
+        <td class="case-image" data-label="Image">
+          <img
+            src="assets/Smol-Panini-Case-by-TigsterCox.webp"
+            loading="lazy"
+          />
+        </td>
+        <td class="case-name" data-label="Name">Smol Panini Case</td>
+        <td class="case-author" data-label="Author">TigsterCox</td>
+        <td class="case-link" data-label="Link">
+          <a href="https://github.com/TigsterCox/Smol-Panini-Case/">Github</a>
+        </td>
+        <td class="case-usb" data-label="USB">✅</td>
+        <td class="case-pcb" data-label="PCB">✖️</td>
+        <td class="case-battery" data-label="Battery">
+          <div class="tooltip-text-container">
+            180 mAh
+            <span class="tooltip-text">601230 Battery</span>
+          </div>
+        </td>
+        <td class="case-dock" data-label="Dock">✖️</td>
+      </tr>
+      <tr>
+        <td class="case-image" data-label="Image">
+          <img src="assets/Ibis Trackers-by-brisfknibis.webp" loading="lazy" />
+        </td>
+        <td class="case-name" data-label="Name">Ibis Trackers</td>
+        <td class="case-author" data-label="Author">brisfknibis</td>
+        <td class="case-link" data-label="Link">
+          <a href="https://github.com/brisfknibis/ibis-trackers/">Github</a>
+        </td>
+        <td class="case-usb" data-label="USB">✅</td>
+        <td class="case-pcb" data-label="PCB">✖️</td>
+        <td class="case-battery" data-label="Battery">
+          <div class="tooltip-text-container">
+            100 mAh
+            <span class="tooltip-text">401030 Battery</span>
+          </div>
+        </td>
+        <td class="case-dock" data-label="Dock">✖️</td>
+      </tr>
+      <tr>
+        <td class="case-image" data-label="Image">
+          <img
+            src="assets/Stacked-SmolSlime-by-LyallUlric.png"
+            loading="lazy"
+          />
+        </td>
+        <td class="case-name" data-label="Name">Stacked SmolSlime</td>
+        <td class="case-author" data-label="Author">LyallUlric</td>
+        <td class="case-link" data-label="Link">
+          <a href="https://www.thingiverse.com/thing:6941615">Thingiverse</a>
+        </td>
+        <td class="case-usb" data-label="USB">✅</td>
+        <td class="case-pcb" data-label="PCB">✖️</td>
+        <td class="case-battery" data-label="Battery">
+          <div class="tooltip-text-container">
+            100 mAh
+            <span class="tooltip-text">401030 Battery</span>
+          </div>
+        </td>
+        <td class="case-dock" data-label="Dock">✖️</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 _Created by Shine Bright ✨ and [Depact](https://github.com/Depact)_

--- a/src/diy/smol-slimes/smol-slimes-community-straps.md
+++ b/src/diy/smol-slimes/smol-slimes-community-straps.md
@@ -12,7 +12,7 @@ This page documents DIY strap solutions from the community.
 ## Tracker Placement
 
 <div class="embeddedVideo">
-    <img src="assets/straps/Tracker Placement.webp" alt="strap image" loading="lazy" style="max-width: 800px"/>
+    <img src="assets/straps/Tracker Placement.webp" alt="strap image" loading="lazy" style="max-width: 800px; width:100%"/>
 </div>
 
 ## Components Guide
@@ -52,75 +52,85 @@ Enhanced grip compared to regular bands.
 Can be found by `Elastic Band With Non-slip Webbing`.
 
 ### 3D Printable Buckles
-<table>
-  <thead>
-    <tr>
-      <th>Image</th>
-      <th>Name</th>
-      <th>Author</th>
-      <th>Link</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <img
-          src="assets/straps/Dovetail Strap Latch 30mm 40mm 50mm SlimeVR Buckles by MoDErahN.webp"
-          loading="lazy"
-          style="max-width: 150px"
-        />
-      </td>
-      <td>Dovetail Strap Latch 30mm 40mm 50mm SlimeVR Buckles</td>
-      <td>MoDErahN</td>
-      <td>
-        <a href="https://www.thingiverse.com/thing:6929026">Thingiverse</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <img
-          src="assets/straps/Brackles V2 30_38_50mm for elastic straps by RDTiel.webp"
-          loading="lazy"
-          style="max-width: 150px"
-        />
-      </td>
-      <td>Brackles V2 30/38/50mm for elastic straps</td>
-      <td>RDTiel</td>
-      <td>
-        <a href="https://www.thingiverse.com/thing:6815793">Thingiverse</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <img
-          src="assets/straps/SlimeVR Straps Clip Hook Extended (Astrix Remix) by Astrlx.webp"
-          loading="lazy"
-          style="max-width: 150px"
-        />
-      </td>
-      <td>SlimeVR Straps Clip Hook Extended (Astrix Remix)</td>
-      <td>Astrlx</td>
-      <td>
-        <a href="https://www.thingiverse.com/thing:6811130">Thingiverse</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <img
-          src="assets/straps/Stock Slime VR Velcro Strap Quick Clip Hooks by Kurzaq.webp"
-          loading="lazy"
-          style="max-width: 150px"
-        />
-      </td>
-      <td>Stock Slime VR Velcro Strap Quick Clip Hooks by Kurzaq</td>
-      <td>Kurzaq</td>
-      <td>
-        <a href="https://www.thingiverse.com/thing:6178909">Thingiverse</a>
-      </td>
-    </tr>
-  </tbody>
-</table>
 
+<div class="table-wrapper">
+    <table>
+        <thead>
+            <tr>
+                <th>Image</th>
+                <th>Name</th>
+                <th>Author</th>
+                <th>Link</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>
+                    <img
+                        src="assets/straps/Dovetail Strap Latch 30mm 40mm 50mm SlimeVR Buckles by MoDErahN.webp"
+                        loading="lazy"
+                        style="max-width: 150px"
+                    />
+                </td>
+                <td>Dovetail Strap Latch 30mm 40mm 50mm SlimeVR Buckles</td>
+                <td>MoDErahN</td>
+                <td>
+                    <a href="https://www.thingiverse.com/thing:6929026"
+                        >Thingiverse</a
+                    >
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <img
+                        src="assets/straps/Brackles V2 30_38_50mm for elastic straps by RDTiel.webp"
+                        loading="lazy"
+                        style="max-width: 150px"
+                    />
+                </td>
+                <td>Brackles V2 30/38/50mm for elastic straps</td>
+                <td>RDTiel</td>
+                <td>
+                    <a href="https://www.thingiverse.com/thing:6815793"
+                        >Thingiverse</a
+                    >
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <img
+                        src="assets/straps/SlimeVR Straps Clip Hook Extended (Astrix Remix) by Astrlx.webp"
+                        loading="lazy"
+                        style="max-width: 150px"
+                    />
+                </td>
+                <td>SlimeVR Straps Clip Hook Extended (Astrix Remix)</td>
+                <td>Astrlx</td>
+                <td>
+                    <a href="https://www.thingiverse.com/thing:6811130"
+                        >Thingiverse</a
+                    >
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <img
+                        src="assets/straps/Stock Slime VR Velcro Strap Quick Clip Hooks by Kurzaq.webp"
+                        loading="lazy"
+                        style="max-width: 150px"
+                    />
+                </td>
+                <td>Stock Slime VR Velcro Strap Quick Clip Hooks by Kurzaq</td>
+                <td>Kurzaq</td>
+                <td>
+                    <a href="https://www.thingiverse.com/thing:6178909"
+                        >Thingiverse</a
+                    >
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ## Full Strap Builds
 

--- a/src/diy/smol-slimes/smol-slimes.css
+++ b/src/diy/smol-slimes/smol-slimes.css
@@ -36,8 +36,26 @@ table.table-sort th {
   visibility: visible;
 }
 
+table>thead>tr>th {
+  white-space: nowrap;
+}
+
+@media (max-width: 1920px) {
+
+  table>thead>tr>th,
+  table>tbody>tr>td {
+    padding: 3px 10px;
+  }
+}
+
 /* Responsive styling for smaller screens */
 @media (max-width: 768px) {
+
+  table>thead>tr>th,
+  table>tbody>tr>td {
+    padding: 3px 5px;
+  }
+
   table.community-builds-table {
     display: block;
   }
@@ -105,9 +123,9 @@ table.table-sort th {
   }
 
   table.community-builds-table tbody td:not(.case-image):not(.case-name)::before {
-    content: attr(data-label) ': ';
+    display: inline-block;
+    content: attr(data-label) ':';
     font-weight: bold;
-    display: contents;
     margin-right: 0.5em;
   }
 


### PR DESCRIPTION
Wrapped tables in `<div class="table-wrapper">`.
Set to tracker placement image fix on smaller resolutions.