### PR TITLE
smol-flashing-firmware.md: Add note for DFU mode via Serial, Link to pre-compiled firmware

### DIFF
--- a/src/diy/smol-slimes/smol-flashing-firmware.md
+++ b/src/diy/smol-slimes/smol-flashing-firmware.md
@@ -24,8 +24,8 @@ Update the bootloader on your SuperMini and XIAO boards before flashing the firm
 1. The device should initially start in DFU mode when new and without a bootloader. The LED should fade on and off.
 1. If the device's LED is not fading on and off, press the reset button twice (or briefly short the RST and GND pins) twice within 0.5 seconds. If the device has existing SlimeNRF firmware, reset it four times.
 1. Obtain the fimware:
-   1. For local builds, navigate to your local Receiver or Tracker repository, then go to ```build\REPOSITORY_NAME\zephyr\``` and copy the "zephyr.uf2" file.
-   1. Alternatively, use [precompiled firmware](./smol-pre-compiled-firmware.md).
+   1. For local builds, navigate to the local Receiver or Tracker repository, then go to ```build\REPOSITORY_NAME\zephyr\``` and copy the "zephyr.uf2" file.
+   1. Alternatively, use the [precompiled firmware](./smol-pre-compiled-firmware.md).
 1. Navigate to the Mass Storage Drive (ex. NICENANO/XIAO-SENSE) from ThisPC.
 1. Paste the file there, and the window should close, causing the device to reboot.
 
@@ -43,14 +43,14 @@ NOTE: On Linux, nRF Connect for Desktop installs nodeJS tools into `~/.nrfconnec
 ### Flashing using nRF Connect for Desktop
 1. Open "Programmer" in the nRF Connect.
 1. Put the device into DFU mode using either of these methods:
-    1. Press the reset button. The LED should begin to fade on and off, indicating the device is in DFU Mode. For the eByte dongle, this is the right button. For Nordic dongle, it is the side button (not the round white button).
-    2. If the dongle already has existing SlimeNRF firmware, you can connect to it using the Serial Terminal in nRF Connect and enter "dfu" to put the device into DFU mode.
+    1. Press the reset button — the LED should begin to fade on and off, indicating the device is in DFU Mode. For the eByte dongle, this is the right button. For the Nordic dongle, it is the side button (not the round white button).
+    2. If the dongle already has existing SlimeNRF firmware, using the Serial Terminal in nRF Connect, and enter ```dfu``` to put the device into DFU mode.
 2. In the top left corner, select your Device.
 3. Click on "Add File".
 4. Select the firmware (.hex) you want to flash:
     1. For local builds, navigate to your local Receiver repository, then select the file located at ```build\REPOSITORY_NAME\zephyr\zephyr.hex```.
     2. Alternatively, use [precompiled firmware](./smol-pre-compiled-firmware.md).
-5. Click the "Write button".
+5. Click the "Write" button.
 
 ### Flashing using nRF Util
 Not documented yet. Relevant documentation:

--- a/src/diy/smol-slimes/smol-flashing-firmware.md
+++ b/src/diy/smol-slimes/smol-flashing-firmware.md
@@ -44,7 +44,7 @@ NOTE: On Linux, nRF Connect for Desktop installs nodeJS tools into `~/.nrfconnec
 1. Open "Programmer" in the nRF Connect.
 1. Put the device into DFU mode using either of these methods:
     1. Press the reset button — the LED should begin to fade on and off, indicating the device is in DFU Mode. For the eByte dongle, this is the right button. For the Nordic dongle, it is the side button (not the round white button).
-    2. If the dongle already has existing SlimeNRF firmware, using the Serial Terminal in nRF Connect, and enter ```dfu``` to put the device into DFU mode.
+    2. If the dongle already has existing SlimeNRF firmware, use the Serial Terminal in nRF Connect, and enter ```dfu``` to put the device into DFU mode.
 2. In the top left corner, select your Device.
 3. Click on "Add File".
 4. Select the firmware (.hex) you want to flash:

--- a/src/diy/smol-slimes/smol-flashing-firmware.md
+++ b/src/diy/smol-slimes/smol-flashing-firmware.md
@@ -23,8 +23,9 @@ Update the bootloader on your SuperMini and XIAO boards before flashing the firm
 1. Connect the device to your computer using a USB data cable.
 1. The device should initially start in DFU mode when new and without a bootloader. The LED should fade on and off.
 1. If the device's LED is not fading on and off, press the reset button twice (or briefly short the RST and GND pins) twice within 0.5 seconds. If the device has existing SlimeNRF firmware, reset it four times.
-1. Navigate to your local Receiver or Tracker repository, then go to ```build\REPOSITORY_NAME\zephyr\```.
-1. Copy zephyr.uf2 file.
+1. Obtain the fimware:
+   1. For local builds, navigate to your local Receiver or Tracker repository, then go to ```build\REPOSITORY_NAME\zephyr\``` and copy the "zephyr.uf2" file.
+   1. Alternatively, use [precompiled firmware](./smol-pre-compiled-firmware.md).
 1. Navigate to the Mass Storage Drive (ex. NICENANO/XIAO-SENSE) from ThisPC.
 1. Paste the file there, and the window should close, causing the device to reboot.
 
@@ -41,11 +42,15 @@ NOTE: On Linux, nRF Connect for Desktop installs nodeJS tools into `~/.nrfconnec
 
 ### Flashing using nRF Connect for Desktop
 1. Open "Programmer" in the nRF Connect.
-1. Press the reset button, and the LED should begin to fade on and off, placing the device in DFU Mode. For eByte dongle, this is the right button. For Nordic dongle, it is the side button (not the round white button).
-1. In the top left corner, select your Device.
-1. Click on "Add File".
-1. Navigate to your local Receiver repository, then select the file located at ```build\REPOSITORY_NAME\zephyr\zephyr.hex```.
-1. Click the "Write button".
+1. Put the device into DFU mode using either of these methods:
+    1. Press the reset button. The LED should begin to fade on and off, indicating the device is in DFU Mode. For the eByte dongle, this is the right button. For Nordic dongle, it is the side button (not the round white button).
+    2. If the dongle already has existing SlimeNRF firmware, you can connect to it using the Serial Terminal in nRF Connect and enter "dfu" to put the device into DFU mode.
+2. In the top left corner, select your Device.
+3. Click on "Add File".
+4. Select the firmware (.hex) you want to flash:
+    1. For local builds, navigate to your local Receiver repository, then select the file located at ```build\REPOSITORY_NAME\zephyr\zephyr.hex```.
+    2. Alternatively, use [precompiled firmware](./smol-pre-compiled-firmware.md).
+5. Click the "Write button".
 
 ### Flashing using nRF Util
 Not documented yet. Relevant documentation:


### PR DESCRIPTION

1. Adds hint about using the Serial Console for putting a device into DFU mode. Useful when updating eByte dongle for example, as the button is normally inaccessible

2. No longer assumes that self-built firmware is used