### PR TITLE
Smol Slime Configurator

### DIFF
--- a/src/smol-slimes/firmware/smol-flashing-firmware.md
+++ b/src/smol-slimes/firmware/smol-flashing-firmware.md
@@ -21,6 +21,7 @@ Update the bootloader on your SuperMini and XIAO boards before flashing the firm
 ```
 
 ### Flashing the Firmware using UF2
+**There is a [SmolSlimeConfigurator](https://github.com/ICantMakeThings/SmolSlimeConfigurator/tree/main) Tool for Linux & Windows that lets you flash your smol-slimes Firmware via a easy UI**
 1. Connect the device to your computer using a USB data cable.
 1. The device should initially start in DFU mode when new and without a bootloader. The LED should fade on and off.
 1. If the device's LED is not fading on and off, press the reset button twice (or briefly short the RST and GND pins) twice within 0.5 seconds. If the device has existing SlimeNRF firmware, reset it four times.

--- a/src/smol-slimes/firmware/smol-pairing-and-calibration.md
+++ b/src/smol-slimes/firmware/smol-pairing-and-calibration.md
@@ -7,6 +7,8 @@
 
 # Firmware Setup
 
+**There is a [SmolSlimeConfigurator](https://github.com/ICantMakeThings/SmolSlimeConfigurator/tree/main) Tool for Linux & Windows that lets you configure your smol-slimes via a easy UI**
+
 ## Accessing the Serial Console
 
 You can interact with the firmware by connecting to the serial console it provides, which is used for pairing and calibration. <br>


### PR DESCRIPTION
Pull Request, from #393 
Pull is just mention this exists in the docs, Ofc open source, readable code, also comes precompiled for linux and windows too.
![image](https://github.com/user-attachments/assets/92771111-948f-400f-a527-1e37bd1607e1)
What it does?
- Configure the trackers via easy buttons
- buttons explained with tooltips
- Automatically shows latest Firmware 
- Flash the trackers practically automatically, select COM, connect, select firmware from the menu press flash and wait 15 seconds.
![image](https://github.com/user-attachments/assets/f3ae138a-cb72-4bb9-8af3-da7248f3934e)

Idk how i should of mentioned it so i just put:
**There is a [SmolSlimeConfigurator](https://github.com/ICantMakeThings/SmolSlimeConfigurator/tree/main) Tool for Linux & Windows that lets you configure your smol-slimes via a easy UI**

