### PR TITLE
Add instructions for putting the HolyIOT dongle into DFU mode

### DIFF
--- a/src/smol-slimes/firmware/smol-flashing-firmware.md
+++ b/src/smol-slimes/firmware/smol-flashing-firmware.md
@@ -45,7 +45,8 @@ NOTE: On Linux, nRF Connect for Desktop installs nodeJS tools into `~/.nrfconnec
 1. Open "Programmer" in the nRF Connect.
 1. Put the device into DFU mode using either of these methods:
     1. Press the reset button — the LED should begin to fade on and off, indicating the device is in DFU Mode. For the eByte dongle, this is the right button. For the Nordic dongle, it is the side button (not the round white button).
-    2. If the dongle already has existing SlimeNRF firmware, use the Serial Terminal in nRF Connect, and enter ```dfu``` to put the device into DFU mode.
+    2. For the Holyiot dongle, tap it with a small magnet. The LED should turn red and begin to fade on and off.
+    3. If the dongle already has existing SlimeNRF firmware, use the Serial Terminal in nRF Connect, and enter ```dfu``` to put the device into DFU mode.
 2. In the top left corner, select your Device.
 3. Click on "Add File".
 4. Select the firmware (.hex) you want to flash:


### PR DESCRIPTION
Not mentioned anywhere else and it's a little confusing.