### PR TITLE
Update Community Page Link

### DIFF
--- a/src/smol-slimes/index.md
+++ b/src/smol-slimes/index.md
@@ -14,7 +14,7 @@ Looking for something simpler than building your own? The Butterfly Tracker is S
 **Disclaimer:** This project is highly experimental. These devices may be incompatible with newer versions of the SlimeVR Server and could require frequent firmware updates. Nothing is final at this stage, including hardware, firmware, and communication protocols.
 ```
 
-- **[Community Builds](community/smol-slimes-community-builds.md)**
+- **[Community Builds](hardware/smol-slimes-community-builds.md)**
   Examples of completed builds, cases, and lists of components you will need to create your own set of matching trackers.
 
 - **[Hardware](hardware/index.md)**


### PR DESCRIPTION
Currently, links to community/smol-slimes-community-builds.html which is a dead link, update to intended link under hardware/smol-slimes-community-builds.html