### PR TITLE
Updated smol set calculator to list options as radio cards and not just radio buttons. Added next steps under calculator.

### DIFF
--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -305,7 +305,8 @@
     ];
 
     /**
-     * Creates and appends a new DOM element to a parent.
+     * Needed to dynamically create and append table cells and rows for each component and choice,
+     * allowing the calculator to build the UI based on the data structure rather than static HTML.
      * @param {HTMLElement} parent - The parent element to append to.
      * @param {string} type - The type of element to create (e.g., 'td', 'tr').
      * @param {string} [contents=""] - The innerHTML for the element.
@@ -319,6 +320,7 @@
     };
 
     /**
+     * Needed to ensure cost values are presented in a user-friendly format.
      * Formats a number to two decimal places, removing trailing ".00" if present.
      * @param {number} value - The number to format.
      * @returns {string} The formatted string, e.g. "18" or "18.25".
@@ -328,8 +330,8 @@
     }
 
     /**
-     * Updates the displayed prices and component amounts based on selected options.
-     * Called when the tracker count or component choices change.
+     * Needed to keep the displayed prices and quantities in sync with user selections,
+     * so the calculator always reflects the current configuration and component choices.
      */
     const updatePrices = () => {
         // IMU number

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -183,11 +183,23 @@
                     </ul>',
                 },
                 {
+                    name: "Generic AliExpress straps + GoPro Chest Strap",
+                    amount: (set) => Math.ceil(set / 5),
+                    cost: () => 5 + 3.66,
+                    costAll: (set) => Math.ceil(set / 5) * 2.67 + 2.77 + 3.66,
+                    links: '\
+                    <a href="https://aliexpress.com/item/1005001908740631.html" target="_blank">AliExpress straps</a>\
+                    <br/><a href="https://www.aliexpress.com/item/1005004792179605.html" target="_blank">GoPro Chest Strap</a>\
+                    <br/>Most cases designed for 30mm wide straps.',
+                },
+                {
                     name: "Generic AliExpress straps",
                     amount: (set) => Math.ceil(set / 5),
                     cost: () => 5,
                     costAll: (set) => Math.ceil(set / 5) * 2.67 + 2.77,
-                    links: '<a href="https://aliexpress.com/item/1005001908740631.html" target="_blank">AliExpress straps</a><br/>Most cases designed for 30mm wide straps.',
+                    links: '\
+                    <a href="https://aliexpress.com/item/1005001908740631.html" target="_blank">AliExpress straps</a>\
+                    <br/>Most cases designed for 30mm wide straps.',
                 },
                 {
                     name: "Generic Amazon straps",

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -12,7 +12,7 @@
             choices: [
                 {
                     name: "nRF52840",
-                    description: "With 20% overage, to help with Dead On Arrival issues",
+                    description: "Includes 20% overage to account for DOA (Dead on Arrival) issues",
                     amount: () => Math.ceil(tracker * 1.2) + " (20% overage)",
                     cost: () => 6.55 / 2,
                     costAll: () => Math.ceil(tracker * 1.2) * (6.55 / 2),
@@ -38,7 +38,7 @@
             choices: [
                 {
                     name: "LSM6DSR",
-                    description: "Half the price of ICM-45686, with slightly more drift",
+                    description: "Half the price of the ICM-45686, but with slightly more drift",
                     amount: (set) => set,
                     cost: () => 3.52,
                     costAll: (set) => set * 3.52 + 6.7,
@@ -46,7 +46,7 @@
                 },
                 {
                     name: "ICM-45686",
-                    description: "More expensive than LSM6DSR, slightly more precise",
+                    description: "More expensive than the LSM6DSR, but slightly more precise",
                     amount: (set) => set,
                     cost: () => 7.44,
                     costAll: (set) => set * 7.44 + 6.7,
@@ -61,7 +61,7 @@
                 },
                 {
                     name: "Nekumori Chrysalis",
-                    description: "ICM-45686 shield with button and RGB LED",
+                    description: "An ICM-45686 shield with a button and RGB LED",
                     amount: (set) => set,
                     cost: () => 10,
                     costAll: (set) => set * 10 + 4.9,
@@ -93,7 +93,7 @@
             choices: [
                 {
                     name: "401230 3.7V 110mAh Battery",
-                    description: "Provides approximately 25 hours of runtime.<br/>Most community cases are designed to accommodate it.",
+                    description: "Provides approximately 25 hours of runtime.<br/>Most community cases are designed to accommodate this battery.",
                     amount: () => tracker,
                     cost: () => 8.49 / 10,
                     costAll: () => tracker * (8.49 / 10) + 5.2,
@@ -113,7 +113,7 @@
             choices: [
                 {
                     name: "Width: 20MM",
-                    description: "Do not skip out on kapton tape. It's essential for not frying your smols if you build stacked.",
+                    description: "Do not skip using Kapton tape—it's essential to prevent short circuits when building stacked setups.",
                     amount: () => 1,
                     cost: () => 1.37,
                     costAll: () => 1.37 + 0.99,
@@ -219,7 +219,7 @@
                     Parts:\
                     <ul>\
                         <li><a href="https://aliexpress.com/item/1005001908740631.html" target="_blank">AliExpress straps</a>\
-                            <br/>Most cases designed for 30mm wide straps.\
+                            <br/>Most cases are designed for 30mm wide straps.\
                         </li>\
                         <li><a href="https://www.aliexpress.com/item/1005004792179605.html" target="_blank">GoPro Chest Strap</a></li>\
                     </ul>',
@@ -233,7 +233,7 @@
                     Parts:\
                     <ul>\
                         <li><a href="https://aliexpress.com/item/1005001908740631.html" target="_blank">AliExpress straps</a>\
-                            <br/>Most cases designed for 30mm wide straps.\
+                            <br/>Most cases are designed for 30mm wide straps.\
                         </li>\
                     </ul>',
                 },
@@ -258,7 +258,7 @@
             choices: [
                 {
                     name: "nRF52840 with Wi-Fi Antenna Mod",
-                    description: "Best price-to-performance ratio. Recommended go-to option.<br/>Range is about 4m, can't pierce walls",
+                    description: "Best price-to-performance ratio. Recommended as the go-to option.<br/>Range is about 4m and cannot penetrate walls",
                     amount: () => 1,
                     cost: () => 6.55 / 2 + 2.7,
                     costAll: () => 6.55 / 2 + 2.7,
@@ -277,7 +277,7 @@
                 },
                 {
                     name: "HolyIOT-21017",
-                    description: "Best performance option.<br/>Good signal over 4m and through walls, but most expensive",
+                    description: "Best performance option.<br/>Good signal over 4m, even through walls, but is the most expensive",
                     amount: () => 1,
                     cost: () => 18.08 + 0.99,
                     costAll: () => 18.08 + 0.99,
@@ -294,7 +294,7 @@
                 },
                 {
                     name: "nRF52840 with Wire Antenna Mod",
-                    description: "Cheapest option, but has the worst range.<br/>Range is about 3m, can't pierce walls",
+                    description: "Cheapest option with the shortest range.<br/>Range is about 3m and cannot penetrate walls",
                     amount: () => 1,
                     cost: () => 6.55 / 2,
                     costAll: () => 6.55 / 2,

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -50,7 +50,7 @@
                     name: "Chrysalis <i>(ICM-45686 shield with button and RGB LED)<i/>",
                     amount: (set) => set,
                     cost: () => 10,
-                    costAll: (set) => set * 10 + 4.90,
+                    costAll: (set) => set * 10 + 4.9,
                     links: '<a href="https://nekumori.pink/products/chysalis-v1_3" target="_blank">Nekumori Chrysalis</a>',
                 },
             ],
@@ -152,8 +152,8 @@
                 {
                     name: "DIY, Depact V2",
                     amount: (set) => set,
-                    cost : (set) => 3.61 + + (set > 9 ? 2 : 1) * 5.07 + 12.62 + 0.99,
-                    costAll: (set) => 3.61 + + (set > 9 ? 2 : 1) * 5.07 + 12.62 + 0.99,
+                    cost: (set) => 3.61 + +(set > 9 ? 2 : 1) * 5.07 + 12.62 + 0.99,
+                    costAll: (set) => 3.61 + +(set > 9 ? 2 : 1) * 5.07 + 12.62 + 0.99,
                     links: '\
                     <a href="smol-slimes-community-straps.html#depact-v2-smol-strap" target="_blank">Depact V2 strap docs</a>\
                     <br/>\
@@ -319,9 +319,9 @@
             const updateValues = (choice) => {
                 component.amount.innerHTML = choice.amount(set);
                 component.cost.innerHTML =
-                    "$" + Math.round(choice.cost(set) * 100) / 100;
+                    "$" + formatCost(choice.cost(set));
                 component.costAll.innerHTML =
-                    "~$" + Math.round(choice.costAll(set) * 100) / 100;
+                    "~$" + formatCost(choice.costAll(set));
                 component.links.innerHTML = choice.links;
 
                 total += choice.costAll(set);
@@ -329,13 +329,15 @@
             if (component.choices.length == 1) {
                 updateValues(component.choices[0]);
             } else {
-                const checkedRadio = component.radioGroup.find(radio => radio.checked);
+                const checkedRadio = component.radioGroup.find(
+                    (radio) => radio.checked
+                );
                 const selectedIndex = checkedRadio ? checkedRadio.value : 0;
                 updateValues(component.choices[selectedIndex]);
             }
         });
 
-        var roundedTotal = Math.round(total * 100) / 100;
+        var roundedTotal = formatCost(total);
         document.getElementById("diy-total-value").innerHTML = roundedTotal;
     };
 
@@ -355,9 +357,12 @@
                 const label = document.createElement("label");
                 label.style.display = "block";
                 label.style.cursor = "pointer";
-                var selectText = choiceObj.cost(tracker) == 0
-                    ? choiceObj.name
-                    : choiceObj.name + ", " + Math.round(choiceObj.cost(tracker) * 100) / 100 + "$";
+                var selectText =
+                    choiceObj.costAll(tracker) == 0
+                        ? choiceObj.name
+                        : `${choiceObj.name}, (${choiceObj
+                              .costAll(tracker)
+                              .toFixed(2)}\$ total)`;
                 // Radio input
                 const radio = document.createElement("input");
                 radio.type = "radio";
@@ -383,4 +388,13 @@
     document.querySelectorAll('input[name="diy-set"]').forEach((set) => {
         set.addEventListener("change", updatePrices);
     });
+
+    /**
+     * Formats a number to two decimal places, removing trailing ".00" if present.
+     * @param {number} value - The number to format.
+     * @returns {string} The formatted string, e.g. "18" or "18.25".
+     */
+    function formatCost(value) {
+        return value.toFixed(2).replace(/\.00$/, "");
+    }
 })();

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -26,14 +26,16 @@
             choices: [
                 //Prices are based on the seller "Simple Robot Store" for AliExpress links.
                 {
-                    name: "LSM6DSR <i>(Half the price of ICM-45686, with slightly more drift)<i/>",
+                    name: "LSM6DSR",
+                    description: "Half the price of ICM-45686, with slightly more drift",
                     amount: (set) => set,
                     cost: () => 3.52,
                     costAll: (set) => set * 3.52 + 6.7,
                     links: '<a href="https://moffshop.deyta.de/products/lsm6dsr" target=\"_blank\">Moffshop LSM6DSR + QMC6309</a>',
                 },
                 {
-                    name: "ICM-45686 <i>(More expensive than LSM6DSR, slightly more precise)<i/>",
+                    name: "ICM-45686",
+                    description: "More expensive than LSM6DSR, slightly more precise",
                     amount: (set) => set,
                     cost: () => 7.44,
                     costAll: (set) => set * 7.44 + 6.7,
@@ -47,7 +49,8 @@
                     links: '<a href="https://moffshop.deyta.de/products/lsm6dsv-module" target="_blank">Moffshop LSM6DSV</a>',
                 },
                 {
-                    name: "Chrysalis <i>(ICM-45686 shield with button and RGB LED)<i/>",
+                    name: "Chrysalis",
+                    description: "ICM-45686 shield with button and RGB LED",
                     amount: (set) => set,
                     cost: () => 10,
                     costAll: (set) => set * 10 + 4.9,
@@ -200,7 +203,8 @@
             name: "Dongle",
             choices: [
                 {
-                    name: "nRF52840 with Wi-Fi Antenna Mod <i>(Best price-to-performance ratio. Recommended go-to option. Range is about 4m, can't pierce walls)<i/>",
+                    name: "nRF52840 with Wi-Fi Antenna Mod",
+                    description: "Best price-to-performance ratio. Recommended go-to option. Range is about 4m, can't pierce walls",
                     amount: () => 1,
                     cost: () => 6.55 / 2 + 2.7,
                     costAll: () => 6.55 / 2 + 2.7,
@@ -218,7 +222,8 @@
                     </ul>',
                 },
                 {
-                    name: "HolyIOT-21017 <i>(Best performance option. Good signal over 4m and through walls, but most expensive)<i/>",
+                    name: "HolyIOT-21017",
+                    description: "Best performance option. Good signal over 4m and through walls, but most expensive",
                     amount: () => 1,
                     cost: () => 18.08 + 0.99,
                     costAll: () => 18.08 + 0.99,
@@ -234,7 +239,8 @@
                     </ul>',
                 },
                 {
-                    name: "nRF52840 with Wire Antenna Mod <i>(Cheapest option, but has the worst range. Range is about 3m, can't pierce walls)<i/>",
+                    name: "nRF52840 with Wire Antenna Mod",
+                    description: "Cheapest option, but has the worst range. Range is about 3m, can't pierce walls",
                     amount: () => 1,
                     cost: () => 6.55 / 2,
                     costAll: () => 6.55 / 2,

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -11,8 +11,8 @@
             name: "Microcontroller",
             choices: [
                 {
-                    name: "nRF52840\
-                    <br/>(With overage, to avoid Dead On Arrival issues)",
+                    name: "nRF52840",
+                    description: "With 20% overage, to avoid Dead On Arrival issues",
                     amount: () => Math.ceil(tracker * 1.2) + " (20% overage)",
                     cost: () => 6.55 / 2,
                     costAll: () => Math.ceil(tracker * 1.2) * (6.55 / 2),
@@ -23,6 +23,13 @@
                             <a href="https://pl.aliexpress.com/item/1005007738886550.html" target=\"_blank\">AliExpress TENSTAR 2pcs pack</a>\
                         </li>\
                     </ul>',
+                },
+                {
+                    name: "Sourced elsewhere",
+                    amount: () => 0,
+                    cost: () => 0,
+                    costAll: () => 0,
+                    links: "",
                 },
             ],
         },
@@ -72,6 +79,13 @@
                     costAll: () => 1.53 / 50 + 0.99,
                     links: '<a href="https://www.aliexpress.com/item/1005007004194449.html" target=\"_blank\">AliExpress 3x4x2mm 2pin, 50 pcs</a>',
                 },
+                {
+                    name: "Sourced elsewhere",
+                    amount: () => 0,
+                    cost: () => 0,
+                    costAll: () => 0,
+                    links: "",
+                },
             ],
         },
         {
@@ -79,11 +93,18 @@
             choices: [
                 {
                     name: "401230 3.7V 110mAh Battery",
-                    description: "Provides approximately 25 hours of runtime. Most community cases are designed to accommodate it.",
+                    description: "Provides approximately 25 hours of runtime.<br/>Most community cases are designed to accommodate it.",
                     amount: () => tracker,
                     cost: () => 8.49 / 10,
                     costAll: () => tracker * (8.49 / 10) + 5.2,
                     links: '<a href="https://www.aliexpress.com/item/714331867.html" target=\"_blank\">AliExpress 401230 3.7V 110mAh Battery, 10 pcs</a>',
+                },
+                {
+                    name: "Sourced elsewhere",
+                    amount: () => 0,
+                    cost: () => 0,
+                    costAll: () => 0,
+                    links: "",
                 },
             ],
         },
@@ -96,6 +117,13 @@
                     cost: () => 1.37,
                     costAll: () => 1.37 + 0.99,
                     links: '<a href="https://www.aliexpress.com/item/1005007518587827.html" target=\"_blank\">AliExpress 5-40mm Kapton Tape</a>',
+                },
+                {
+                    name: "Sourced elsewhere",
+                    amount: () => 0,
+                    cost: () => 0,
+                    costAll: () => 0,
+                    links: "",
                 },
             ],
         },

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -188,9 +188,13 @@
                     cost: () => 5 + 3.66,
                     costAll: (set) => Math.ceil(set / 5) * 2.67 + 2.77 + 3.66,
                     links: '\
-                    <a href="https://aliexpress.com/item/1005001908740631.html" target="_blank">AliExpress straps</a>\
-                    <br/><a href="https://www.aliexpress.com/item/1005004792179605.html" target="_blank">GoPro Chest Strap</a>\
-                    <br/>Most cases designed for 30mm wide straps.',
+                    Parts:\
+                    <ul>\
+                        <li><a href="https://aliexpress.com/item/1005001908740631.html" target="_blank">AliExpress straps</a>\
+                            <br/>Most cases designed for 30mm wide straps.\
+                        </li>\
+                        <li><a href="https://www.aliexpress.com/item/1005004792179605.html" target="_blank">GoPro Chest Strap</a></li>\
+                    </ul>',
                 },
                 {
                     name: "Generic AliExpress straps",
@@ -198,8 +202,12 @@
                     cost: () => 5,
                     costAll: (set) => Math.ceil(set / 5) * 2.67 + 2.77,
                     links: '\
-                    <a href="https://aliexpress.com/item/1005001908740631.html" target="_blank">AliExpress straps</a>\
-                    <br/>Most cases designed for 30mm wide straps.',
+                    Parts:\
+                    <ul>\
+                        <li><a href="https://aliexpress.com/item/1005001908740631.html" target="_blank">AliExpress straps</a>\
+                            <br/>Most cases designed for 30mm wide straps.\
+                        </li>\
+                    </ul>',
                 },
                 {
                     name: "Generic Amazon straps",

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -406,6 +406,7 @@
     /**
      * Needed to generate a radio group for component choices,
      * so users can select between multiple options for a component.
+     * Renders each option as a card with name, description, and total cost.
      * @param {Object} component
      * @param {HTMLElement} choiceCell
      */
@@ -413,13 +414,12 @@
         component.radioGroup = [];
         component.radioName = "name-" + component.name;
         component.choices.forEach((choiceObj, index) => {
-            const label = document.createElement("label");
-            label.style.display = "block";
-            label.style.cursor = "pointer";
-            var selectText =
-                choiceObj.costAll(tracker) == 0
-                    ? choiceObj.name
-                    : `${choiceObj.name}, (${choiceObj.costAll(tracker).toFixed(2)}\$ total)`;
+            // Card container
+            const card = document.createElement("div");
+            card.className = "radio-card";
+            card.tabIndex = 0;
+            card.style.cursor = "pointer";
+
             // Radio input
             const radio = document.createElement("input");
             radio.type = "radio";
@@ -428,10 +428,51 @@
             if (index === 0) radio.checked = true;
             radio.addEventListener("change", updatePrices);
             component.radioGroup.push(radio);
-            label.appendChild(radio);
-            // Label text
-            label.insertAdjacentHTML("beforeend", " " + selectText);
-            choiceCell.appendChild(label);
+
+            // Make card clickable to select radio
+            card.addEventListener("click", () => {
+                radio.checked = true;
+                updatePrices();
+            });
+
+            // Also allow keyboard selection
+            card.addEventListener("keydown", (e) => {
+                if (e.key === " " || e.key === "Enter") {
+                    radio.checked = true;
+                    updatePrices();
+                    e.preventDefault();
+                }
+            });
+
+            // Info container
+            const info = document.createElement("div");
+            info.className = "radio-card-info";
+
+            // Name
+            const nameEl = document.createElement("div");
+            nameEl.className = "radio-card-name";
+            nameEl.innerHTML = choiceObj.name;
+
+            // Description (if present)
+            if (choiceObj.description) {
+                const descEl = document.createElement("div");
+                descEl.className = "radio-card-desc";
+                descEl.innerHTML = choiceObj.description;
+                info.appendChild(descEl);
+            }
+
+            info.appendChild(nameEl);
+
+            // Cost
+            const costEl = document.createElement("div");
+            costEl.className = "radio-card-cost";
+            costEl.innerHTML = `~$${choiceObj.costAll(tracker).toFixed(2)} total`;
+
+            card.appendChild(radio);
+            card.appendChild(info);
+            card.appendChild(costEl);
+
+            choiceCell.appendChild(card);
         });
     }
 

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -404,6 +404,38 @@
     };
 
     /**
+     * Needed to generate a radio group for component choices,
+     * so users can select between multiple options for a component.
+     * @param {Object} component
+     * @param {HTMLElement} choiceCell
+     */
+    function createRadioGroup(component, choiceCell) {
+        component.radioGroup = [];
+        component.radioName = "name-" + component.name;
+        component.choices.forEach((choiceObj, index) => {
+            const label = document.createElement("label");
+            label.style.display = "block";
+            label.style.cursor = "pointer";
+            var selectText =
+                choiceObj.costAll(tracker) == 0
+                    ? choiceObj.name
+                    : `${choiceObj.name}, (${choiceObj.costAll(tracker).toFixed(2)}\$ total)`;
+            // Radio input
+            const radio = document.createElement("input");
+            radio.type = "radio";
+            radio.name = component.radioName;
+            radio.value = index;
+            if (index === 0) radio.checked = true;
+            radio.addEventListener("change", updatePrices);
+            component.radioGroup.push(radio);
+            label.appendChild(radio);
+            // Label text
+            label.insertAdjacentHTML("beforeend", " " + selectText);
+            choiceCell.appendChild(label);
+        });
+    }
+
+    /**
      * Needed to create and initialize a table row for each component,
      * so the calculator UI is generated dynamically from the data structure.
      * @param {Object} component
@@ -418,29 +450,7 @@
         if (component.choices.length == 1) {
             choice.innerHTML = component.choices[0].name;
         } else {
-            component.radioGroup = [];
-            component.radioName = "name-" + component.name;
-            component.choices.forEach((choiceObj, index) => {
-                const label = document.createElement("label");
-                label.style.display = "block";
-                label.style.cursor = "pointer";
-                var selectText =
-                    choiceObj.costAll(tracker) == 0
-                        ? choiceObj.name
-                        : `${choiceObj.name}, (${choiceObj.costAll(tracker).toFixed(2)}\$ total)`;
-                // Radio input
-                const radio = document.createElement("input");
-                radio.type = "radio";
-                radio.name = component.radioName;
-                radio.value = index;
-                if (index === 0) radio.checked = true;
-                radio.addEventListener("change", updatePrices);
-                component.radioGroup.push(radio);
-                label.appendChild(radio);
-                // Label text
-                label.insertAdjacentHTML("beforeend", " " + selectText);
-                choice.appendChild(label);
-            });
+            createRadioGroup(component, choice);
         }
 
         component.amount = makeElement(tr, "td");

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -113,7 +113,7 @@
             choices: [
                 {
                     name: "Width: 20MM",
-                    description: "Do not skip out on kapton tape. It's essential for not frying your smols.",
+                    description: "Do not skip out on kapton tape. It's essential for not frying your smols if you build stacked.",
                     amount: () => 1,
                     cost: () => 1.37,
                     costAll: () => 1.37 + 0.99,

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -29,7 +29,6 @@
         {
             name: "IMU",
             choices: [
-                //Prices are based on the seller "Simple Robot Store" for AliExpress links.
                 {
                     name: "LSM6DSR",
                     description: "Half the price of ICM-45686, with slightly more drift",

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -12,7 +12,7 @@
             choices: [
                 {
                     name: "nRF52840",
-                    description: "With 20% overage, to avoid Dead On Arrival issues",
+                    description: "With 20% overage, to help with Dead On Arrival issues",
                     amount: () => Math.ceil(tracker * 1.2) + " (20% overage)",
                     cost: () => 6.55 / 2,
                     costAll: () => Math.ceil(tracker * 1.2) * (6.55 / 2),
@@ -113,6 +113,7 @@
             choices: [
                 {
                     name: "Width: 20MM",
+                    description: "Do not skip out on kapton tape. It's essential for not frying your smols.",
                     amount: () => 1,
                     cost: () => 1.37,
                     costAll: () => 1.37 + 0.99,

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -13,9 +13,9 @@
                 {
                     name: "nRF52840\
                     <br/>(With overage, to avoid Dead On Arrival issues)",
-                    amount: () => Math.round(tracker * 1.2) + " (20% overage)",
+                    amount: () => Math.ceil(tracker * 1.2) + " (20% overage)",
                     cost: () => 6.55 / 2,
-                    costAll: () => Math.round(tracker * 1.2) * (6.55 / 2),
+                    costAll: () => Math.ceil(tracker * 1.2) * (6.55 / 2),
                     links: '\
                     Available on AliExpress with <code>compatible with nice!nano</code>, <code>SuperMini</code>, or<code>Pro Micro</code> branding.\
                     <ul>\
@@ -161,8 +161,8 @@
                 {
                     name: "DIY, Depact V2",
                     amount: (set) => set,
-                    cost: (set) => 3.61 + +(set > 9 ? 2 : 1) * 5.07 + 12.62 + 0.99,
-                    costAll: (set) => 3.61 + +(set > 9 ? 2 : 1) * 5.07 + 12.62 + 0.99,
+                    cost: (set) => 3.66 + +(set > 9 ? 2 : 1) * 5.07 + 12.62 + 0.99,
+                    costAll: (set) => 3.66 + +(set > 9 ? 2 : 1) * 5.07 + 12.62 + 0.99,
                     links: '\
                     <a href="smol-slimes-community-straps.html#depact-v2-smol-strap" target="_blank">Depact V2 strap docs</a>\
                     <br/>\
@@ -183,14 +183,14 @@
                     </ul>',
                 },
                 {
-                    name: "Generic AliExpress straps - 6 pcs",
-                    amount: (set) => (set <= 6 ? 1 : 2),
+                    name: "Generic AliExpress straps",
+                    amount: (set) => Math.ceil(set / 5),
                     cost: () => 5,
-                    costAll: (set) => (set <= 6 ? 1 : 2) * 5 + 2.77,
-                    links: '<a href="https://aliexpress.com/item/1005001908740631.html" target="_blank">AliExpress straps</a>, get some in different sizes?',
+                    costAll: (set) => Math.ceil(set / 5) * 2.67 + 2.77,
+                    links: '<a href="https://aliexpress.com/item/1005001908740631.html" target="_blank">AliExpress straps</a><br/>Most cases designed for 30mm wide straps.',
                 },
                 {
-                    name: "Generic Amazon straps - 5 pcs",
+                    name: "Generic Amazon straps",
                     amount: (set) => (set < 5 ? 1 : 2),
                     cost: () => 9.0,
                     costAll: (set) => (set < 5 ? 1 : 2) * 9.0,
@@ -284,9 +284,9 @@
                 },
                 {
                     name: "Depact Smol Sudo Dock",
-                    amount: () => Math.round(tracker / 7),
-                    cost: () => Math.round(tracker / 7) * 6.38 + tracker * 0.36,
-                    costAll: () => Math.round(tracker / 7) * 6.38 + tracker * 0.36,
+                    amount: () => Math.ceil(tracker / 7),
+                    cost: () => Math.ceil(tracker / 7) * 6.38 + tracker * 0.36,
+                    costAll: () => Math.ceil(tracker / 7) * 6.38 + tracker * 0.36,
                     links: '\
                     <a href=\"smol-slimes-community-builds.html#depact-smol-sudo-dock" target="_blank">Depact Smol Sudo Dock docs reference.</a>\
                     <br/>\

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -54,7 +54,7 @@
                     links: '<a href="https://moffshop.deyta.de/products/lsm6dsv-module" target="_blank">Moffshop LSM6DSV</a>',
                 },
                 {
-                    name: "Chrysalis",
+                    name: "Nekumori Chrysalis",
                     description: "ICM-45686 shield with button and RGB LED",
                     amount: (set) => set,
                     cost: () => 10,
@@ -79,7 +79,8 @@
             name: "Batteries",
             choices: [
                 {
-                    name: "401230 3.7V 110mAh Battery.<br/><i>Provides approximately 25 hours of runtime.<br/>Most community cases are designed to accommodate it.<i/>",
+                    name: "401230 3.7V 110mAh Battery",
+                    description: "Provides approximately 25 hours of runtime. Most community cases are designed to accommodate it.",
                     amount: () => tracker,
                     cost: () => 8.49 / 10,
                     costAll: () => tracker * (8.49 / 10) + 5.2,
@@ -430,10 +431,10 @@
             });
         }
 
-        component.amount = makeElement(tr, "td", 0);
-        component.cost = makeElement(tr, "td", 0);
-        component.costAll = makeElement(tr, "td", 0);
-        component.links = makeElement(tr, "td", 69);
+        component.amount = makeElement(tr, "td", 5555);
+        component.cost = makeElement(tr, "td", 5555);
+        component.costAll = makeElement(tr, "td", 5555);
+        component.links = makeElement(tr, "td", 5555);
     });
 
     updatePrices();

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -1,3 +1,8 @@
+/**
+ * Smol Slimes DIY Building Calculator
+ * Dynamically generates a table of component choices and calculates total cost for building SlimeVR trackers.
+ * @module smol-building-calculator
+ */
 (() => {
     var tracker = 6; // Default number of trackers
 
@@ -299,6 +304,13 @@
         },
     ];
 
+    /**
+     * Creates and appends a new DOM element to a parent.
+     * @param {HTMLElement} parent - The parent element to append to.
+     * @param {string} type - The type of element to create (e.g., 'td', 'tr').
+     * @param {string} [contents=""] - The innerHTML for the element.
+     * @returns {HTMLElement} The created element.
+     */
     const makeElement = (parent, type, contents = "") => {
         let el = document.createElement(type);
         el.innerHTML = contents;
@@ -306,8 +318,19 @@
         return el;
     };
 
-    const tbody = document.getElementById("diy-components");
+    /**
+     * Formats a number to two decimal places, removing trailing ".00" if present.
+     * @param {number} value - The number to format.
+     * @returns {string} The formatted string, e.g. "18" or "18.25".
+     */
+    function formatCost(value) {
+        return value.toFixed(2).replace(/\.00$/, "");
+    }
 
+    /**
+     * Updates the displayed prices and component amounts based on selected options.
+     * Called when the tracker count or component choices change.
+     */
     const updatePrices = () => {
         // IMU number
         const set = document.querySelector("input[name=diy-set]:checked").value;
@@ -347,6 +370,7 @@
         document.getElementById("diy-total-value").innerHTML = roundedTotal;
     };
 
+    const tbody = document.getElementById("diy-components");
     components.forEach((component) => {
         const tr = makeElement(tbody, "tr");
         component.tr = tr;
@@ -394,13 +418,4 @@
     document.querySelectorAll('input[name="diy-set"]').forEach((set) => {
         set.addEventListener("change", updatePrices);
     });
-
-    /**
-     * Formats a number to two decimal places, removing trailing ".00" if present.
-     * @param {number} value - The number to format.
-     * @returns {string} The formatted string, e.g. "18" or "18.25".
-     */
-    function formatCost(value) {
-        return value.toFixed(2).replace(/\.00$/, "");
-    }
 })();

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -368,9 +368,19 @@
             const selectedIndex = getSelectedChoiceIndex(component.radioGroup);
             choice = component.choices[selectedIndex];
         }
-        component.amount.innerHTML = choice.amount(set);
-        component.cost.innerHTML = "$" + formatCost(choice.cost(set));
-        component.costAll.innerHTML = "~$" + formatCost(choice.costAll(set));
+        if (choice.amount(set) != 0) {
+            component.amount.innerHTML = choice.amount(set);
+        }
+
+        if (choice.costAll(set) != 0) {
+            component.cost.innerHTML = "$" + formatCost(choice.cost(set));
+        }
+
+        if (choice.costAll(set) != 0) {
+            component.costAll.innerHTML =
+                "~$" + formatCost(choice.costAll(set));
+        }
+
         component.links.innerHTML = choice.links;
         return choice.costAll(set);
     }
@@ -393,8 +403,13 @@
         document.getElementById("diy-total-value").innerHTML = roundedTotal;
     };
 
-    const tbody = document.getElementById("diy-components");
-    components.forEach((component) => {
+    /**
+     * Needed to create and initialize a table row for each component,
+     * so the calculator UI is generated dynamically from the data structure.
+     * @param {Object} component
+     * @param {HTMLElement} tbody
+     */
+    function createComponentRow(component, tbody) {
         const tr = makeElement(tbody, "tr");
         component.tr = tr;
         makeElement(tr, "th", component.name);
@@ -431,11 +446,14 @@
             });
         }
 
-        component.amount = makeElement(tr, "td", 5555);
-        component.cost = makeElement(tr, "td", 5555);
-        component.costAll = makeElement(tr, "td", 5555);
-        component.links = makeElement(tr, "td", 5555);
-    });
+        component.amount = makeElement(tr, "td");
+        component.cost = makeElement(tr, "td");
+        component.costAll = makeElement(tr, "td");
+        component.links = makeElement(tr, "td");
+    }
+
+    const tbody = document.getElementById("diy-components");
+    components.forEach((component) => createComponentRow(component, tbody));
 
     updatePrices();
     document.querySelectorAll('input[name="diy-set"]').forEach((set) => {

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -418,7 +418,6 @@
         if (component.choices.length == 1) {
             choice.innerHTML = component.choices[0].name;
         } else {
-            // Generate radio buttons instead of select
             component.radioGroup = [];
             component.radioName = "name-" + component.name;
             component.choices.forEach((choiceObj, index) => {

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -368,6 +368,7 @@
             const selectedIndex = getSelectedChoiceIndex(component.radioGroup);
             choice = component.choices[selectedIndex];
         }
+    
         if (choice.amount(set) != 0) {
             component.amount.innerHTML = choice.amount(set);
         }
@@ -377,8 +378,7 @@
         }
 
         if (choice.costAll(set) != 0) {
-            component.costAll.innerHTML =
-                "~$" + formatCost(choice.costAll(set));
+            component.costAll.innerHTML = "~$" + formatCost(choice.costAll(set));
         }
 
         component.links.innerHTML = choice.links;
@@ -428,9 +428,7 @@
                 var selectText =
                     choiceObj.costAll(tracker) == 0
                         ? choiceObj.name
-                        : `${choiceObj.name}, (${choiceObj
-                              .costAll(tracker)
-                              .toFixed(2)}\$ total)`;
+                        : `${choiceObj.name}, (${choiceObj.costAll(tracker).toFixed(2)}\$ total)`;
                 // Radio input
                 const radio = document.createElement("input");
                 radio.type = "radio";

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -210,7 +210,7 @@
             choices: [
                 {
                     name: "nRF52840 with Wi-Fi Antenna Mod",
-                    description: "Best price-to-performance ratio. Recommended go-to option. Range is about 4m, can't pierce walls",
+                    description: "Best price-to-performance ratio. Recommended go-to option.<br/>Range is about 4m, can't pierce walls",
                     amount: () => 1,
                     cost: () => 6.55 / 2 + 2.7,
                     costAll: () => 6.55 / 2 + 2.7,
@@ -229,7 +229,7 @@
                 },
                 {
                     name: "HolyIOT-21017",
-                    description: "Best performance option. Good signal over 4m and through walls, but most expensive",
+                    description: "Best performance option.<br/>Good signal over 4m and through walls, but most expensive",
                     amount: () => 1,
                     cost: () => 18.08 + 0.99,
                     costAll: () => 18.08 + 0.99,
@@ -246,7 +246,7 @@
                 },
                 {
                     name: "nRF52840 with Wire Antenna Mod",
-                    description: "Cheapest option, but has the worst range. Range is about 3m, can't pierce walls",
+                    description: "Cheapest option, but has the worst range.<br/>Range is about 3m, can't pierce walls",
                     amount: () => 1,
                     cost: () => 6.55 / 2,
                     costAll: () => 6.55 / 2,
@@ -452,6 +452,7 @@
             const nameEl = document.createElement("div");
             nameEl.className = "radio-card-name";
             nameEl.innerHTML = choiceObj.name;
+            info.appendChild(nameEl);
 
             // Description (if present)
             if (choiceObj.description) {
@@ -461,12 +462,10 @@
                 info.appendChild(descEl);
             }
 
-            info.appendChild(nameEl);
-
-            // Cost
+            // Cost (goes last)
             const costEl = document.createElement("div");
             costEl.className = "radio-card-cost";
-            costEl.innerHTML = `~$${choiceObj.costAll(tracker).toFixed(2)} total`;
+            costEl.innerHTML = `~$${choiceObj.costAll(tracker).toFixed(2)}`;
 
             card.appendChild(radio);
             card.appendChild(info);
@@ -491,7 +490,11 @@
         if (component.choices.length == 1) {
             choice.innerHTML = component.choices[0].name;
         } else {
-            createRadioGroup(component, choice);
+            // Add radio-card-group wrapper
+            const group = document.createElement("div");
+            group.className = "radio-card-group";
+            choice.appendChild(group);
+            createRadioGroup(component, group);
         }
 
         component.amount = makeElement(tr, "td");

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -284,9 +284,9 @@
                 },
                 {
                     name: "Depact Smol Sudo Dock",
-                    amount: () => Math.round(tracker/7),
-                    cost: () => Math.round(tracker/7) * 6.38 + tracker * 0.36,
-                    costAll: () => Math.round(tracker/7) * 6.38 + tracker * 0.36,
+                    amount: () => Math.round(tracker / 7),
+                    cost: () => Math.round(tracker / 7) * 6.38 + tracker * 0.36,
+                    costAll: () => Math.round(tracker / 7) * 6.38 + tracker * 0.36,
                     links: '\
                     <a href=\"smol-slimes-community-builds.html#depact-smol-sudo-dock" target="_blank">Depact Smol Sudo Dock docs reference.</a>\
                     <br/>\

--- a/src/smol-slimes/assets/js/smol-building-calculator.js
+++ b/src/smol-slimes/assets/js/smol-building-calculator.js
@@ -456,7 +456,5 @@
     components.forEach((component) => createComponentRow(component, tbody));
 
     updatePrices();
-    document.querySelectorAll('input[name="diy-set"]').forEach((set) => {
-        set.addEventListener("change", updatePrices);
-    });
+    document.querySelectorAll('input[name="diy-set"]').forEach((set) => set.addEventListener("change", updatePrices));
 })();

--- a/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
+++ b/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
@@ -1,25 +1,63 @@
 # Smol DIY Set Cost Calculator
 
+## Amount Of Trackers
+
 Before you start, decide on [how many trackers you may need](../../../slimevr101.md#how-many-trackers-do-you-need).
 
-<fieldset class="amount-of-trackers">
-  <legend>Amount of trackers:</legend>
-  <label>
-    <input type="radio" name="diy-set" value="5" /> &nbsp&nbsp5 Trackers - Lower-Body Set
-  </label>
-  <label>
-    <input type="radio" name="diy-set" value="6" checked="checked" /> &nbsp&nbsp6 Trackers - Core Set
-  </label>
-  <label>
-    <input type="radio" name="diy-set" value="8" /> &nbsp&nbsp8 Trackers - Enhanced Core Set
-  </label>
-  <label>
-    <input type="radio" name="diy-set" value="10" /> 10 Trackers - Full-Body Set
-  </label>
-  <label>
-    <input type="radio" name="diy-set" value="16" /> 16 Trackers - Deluxe Tracker Set
-  </label>
-</fieldset>
+<div class="radio-card-group">
+  <div class="radio-card">
+    <input type="radio" name="diy-set" value="5" id="trackers-5" />
+    <label for="trackers-5">
+      <div class="radio-card-name">Lower-Body Set</div>
+      <div class="radio-card-desc">5 IMUs &mdash; Casual VR users</div>
+      <div class="radio-card-desc">
+        Provides positional tracking for legs and spine. Limited tracking for foot orientation and lower spine bending.
+      </div>
+    </label>
+  </div>
+  <div class="radio-card">
+    <input type="radio" name="diy-set" value="6" id="trackers-6" checked="checked" />
+    <label for="trackers-6">
+      <div class="radio-card-name">Core Set</div>
+      <div class="radio-card-desc">6 IMUs &mdash; Users who want better stability</div>
+      <div class="radio-card-desc">
+        Adds an extra spine tracker for improved stability, especially when sitting, lying down, or bending over.
+      </div>
+    </label>
+  </div>
+  <div class="radio-card">
+    <input type="radio" name="diy-set" value="8" id="trackers-8" />
+    <label for="trackers-8">
+      <div class="radio-card-name">Enhanced Core Set</div>
+      <div class="radio-card-desc">8 IMUs &mdash; Users who sit or lie down often</div>
+      <div class="radio-card-desc">
+        Adds foot movement tracking for more expressive, emotive poses when seated or lying down.
+      </div>
+    </label>
+  </div>
+  <div class="radio-card">
+    <input type="radio" name="diy-set" value="10" id="trackers-10" />
+    <label for="trackers-10">
+      <div class="radio-card-name">Full-Body Set</div>
+      <div class="radio-card-desc">10 IMUs &mdash; Dancers, role-players, immersive users</div>
+      <div class="radio-card-desc">
+        Enables independent elbow movement, providing more realistic upper-body motion and increased immersion in VR.
+      </div>
+    </label>
+  </div>
+  <div class="radio-card">
+    <input type="radio" name="diy-set" value="16" id="trackers-16" />
+    <label for="trackers-16">
+      <div class="radio-card-name">Deluxe Tracker Set</div>
+      <div class="radio-card-desc">16 IMUs &mdash; Motion capture professionals, animators</div>
+      <div class="radio-card-desc">
+        Can be used for motion capture without VR gear, split into two Enhanced Core Sets, or customized as needed for flexibility and precision.
+      </div>
+    </label>
+  </div>
+</div>
+
+## Parts
 
 <div class="table-wrapper">
     <table>
@@ -71,7 +109,7 @@ fieldset {
     font-size: large;
 }
 
-.amount-of-trackers {
+.radio-card-group {
     display: flex;
     flex-direction: column;
     margin-bottom: 10px;

--- a/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
+++ b/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
@@ -45,6 +45,13 @@ Before you start, decide on [how many trackers you may need](../../../slimevr101
 
 <hr/>
 
+Once gathered parts those steps remain to build fully functional set:
+1. [Smol Tracker Soldering](./smol-tracker-soldering.md)
+2. [Smol Flashing Firmware](../firmware/smol-flashing-firmware.md)
+3. [Smol Pairing & Calibration](../firmware/smol-pairing-and-calibration.md)
+
+<hr/>
+
 *Created by Shine Bright ✨ and [Depact](https://github.com/Depact)*
 
 <script src="../assets/js/smol-building-calculator.js"></script>

--- a/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
+++ b/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
@@ -78,10 +78,10 @@ Before you start, decide on [how many trackers you may need](../../../slimevr101
 
 <div class="total-cost">
   <strong>TOTAL COST:</strong>
-  ~$<span id="diy-total-value"></span>
+  ~<span id="diy-total-value"></span>
 </div>
 
-<hr/>
+## Steps After Acquiring Parts
 
 Once gathered parts those steps remain to build fully functional set:
 1. [Smol Tracker Soldering](./smol-tracker-soldering.md)
@@ -110,6 +110,8 @@ fieldset {
 }
 
 .radio-card-group {
+    padding-top: 10px;
+    padding-bottom: 10px;
     display: flex;
     flex-direction: column;
     margin-bottom: 10px;
@@ -146,13 +148,19 @@ td label {
 }
 
 .radio-card {
-    border: 1px solid var(--sidebar-bg);
+    border: 1px solid var(--theme-popup-border);
     border-radius: 6px;
     padding: 8px;
     margin-bottom: 6px;
     display: flex;
     align-items: center;
     gap: 12px;
+}
+
+/* Outline for selected card */
+.radio-card:has(input[type="radio"]:checked) {
+    outline: 2px solid var(--sidebar-active);
+    outline-offset: 2px;
 }
 
 .radio-card-info {

--- a/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
+++ b/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
@@ -1,15 +1,15 @@
 # Smol DIY Set Cost Calculator
 
 ```admonish info
-Default selected values catered to offer best price-to-performance balance. 
+Default selected values are chosen to offer the best price-to-performance balance.
 
-For better performance change selection to those values: 
+For better performance, change the selection to the following values:
 - Dongle: HolyIOT-21017
 - IMU: ICM-45686
 ```
 
 
-## Select Amount Of Trackers
+## Select Number of Trackers
 
 Before you start, decide on [how many trackers you may need](../../../slimevr101.md#how-many-trackers-do-you-need).
 

--- a/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
+++ b/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
@@ -94,4 +94,31 @@ td:first-of-type {
 td label {
   padding-bottom: 10px;
 }
+
+.radio-card {
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    padding: 8px;
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.radio-card-info {
+    flex: 1;
+}
+
+.radio-card-name {
+    font-weight: bold;
+}
+
+.radio-card-desc {
+    font-size: 0.95em;
+}
+
+.radio-card-cost {
+    font-weight: bold;
+    margin-left: 16px;
+}
 </style>

--- a/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
+++ b/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
@@ -95,8 +95,13 @@ td label {
   padding-bottom: 10px;
 }
 
+.radio-card-group {
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+
 .radio-card {
-    border: 1px solid #ccc;
+    border: 1px solid var(--sidebar-bg);
     border-radius: 6px;
     padding: 8px;
     margin-bottom: 6px;

--- a/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
+++ b/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
@@ -1,7 +1,7 @@
 # Smol DIY Set Cost Calculator
 
 ```admonish info
-Default selections offer the best price-to-performance balance. 
+Default selected values catered to offer best price-to-performance balance. 
 
 For better performance change selection to those values: 
 - Dongle: HolyIOT-21017

--- a/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
+++ b/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
@@ -1,6 +1,6 @@
 # Smol DIY Set Cost Calculator
 
-## Amount Of Trackers
+## Select Amount Of Trackers
 
 Before you start, decide on [how many trackers you may need](../../../slimevr101.md#how-many-trackers-do-you-need).
 
@@ -57,7 +57,7 @@ Before you start, decide on [how many trackers you may need](../../../slimevr101
   </div>
 </div>
 
-## Parts
+## Select Parts
 
 <div class="table-wrapper">
     <table>

--- a/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
+++ b/src/smol-slimes/hardware/smol-diy-set-cost-calculator.md
@@ -1,5 +1,14 @@
 # Smol DIY Set Cost Calculator
 
+```admonish info
+Default selections offer the best price-to-performance balance. 
+
+For better performance change selection to those values: 
+- Dongle: HolyIOT-21017
+- IMU: ICM-45686
+```
+
+
 ## Select Amount Of Trackers
 
 Before you start, decide on [how many trackers you may need](../../../slimevr101.md#how-many-trackers-do-you-need).

--- a/src/smol-slimes/hardware/smol-slimes-community-builds.md
+++ b/src/smol-slimes/hardware/smol-slimes-community-builds.md
@@ -6,6 +6,11 @@
 This page is dedicated only to builds that others can build themselves. Builds that are not open-source or do not provide sufficient documentation to be replicated are not listed here.
 ```
 
+## Table Of Contents
+
+- TOC
+{:toc}
+
 ## Builds table
 
 <div class="table-wrapper">

--- a/src/smol-slimes/hardware/smol-slimes-community-straps.md
+++ b/src/smol-slimes/hardware/smol-slimes-community-straps.md
@@ -44,6 +44,10 @@ This setup is extremely minimal. It's recommended to replace the buckle with a g
 
 #### Required Components
 
+```admonish info
+5 meters of elastic band is generally enough for 6 straps for an average European XL-sized man.
+```
+
 | Component                                              | Listing Name                                                                                                                     | Color/Variant             | Link                                                                |
 | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------- |
 | Belt Buckles with webbing size 32mm, 10pcs pack        | 20mm 25mm 32mm~50mm Plastic Hardware Dual Adjustable Side Release Buckles Molle Tatical Backpack Belt Bag Parts Strap Webbing    | Webbing Size 32mm, 10pcs  | [AliExpress](https://pl.aliexpress.com/item/32804319193.html)       |
@@ -85,14 +89,16 @@ Same bare-bones and modular approach as V1, but it also requires a needle and th
 
 #### Required Components
 
+```admonish info
+5 meters of elastic band is generally enough for 6 straps for an average European XL-sized man.
+```
+
 | Component                                              | Listing Name                                                                                                                     | Color/Variant             | Link                                                                |
 | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------- |
 | Belt Buckles with webbing size 32mm, 10pcs pack        | 20mm 25mm 32mm~50mm Plastic Hardware Dual Adjustable Side Release Buckles Molle Tatical Backpack Belt Bag Parts Strap Webbing    | Webbing Size 32mm, 10pcs  | [AliExpress](https://pl.aliexpress.com/item/32804319193.html)       |
 | 5m of 30mm Elastic Band with Non-slip Silicone Webbing | Meetee 2/5/10Meters Elastic Band 20-50mm Non-slip Webbing For Belt Garment Wave Silicone Ribbon DIY Clothes Sewing Accessories   | EB312-Black-30mm, 5Meters | [AliExpress](https://www.aliexpress.com/item/1005003917576160.html) |
 | GoPro Chest Strap                                      | Chest Strap Mount Belt for Gopro Hero 9 8 7 6 5 4 Insta360 R X2 DJI OSMO Action Camera Harness for Go Pro SJCAM EKEN Accessories | Black                     | [AliExpress](https://www.aliexpress.com/item/1005004792179605.html) |
 | Needle and thread                                      | Common in DIY and specialized shops                                                                                              |                           |                                                                     |
-
-**Note:** 5 meters of band was enough for 7 straps for an average European XL-sized man.
 
 ## Contributing
 

--- a/src/smol-slimes/hardware/smol-slimes-community-straps.md
+++ b/src/smol-slimes/hardware/smol-slimes-community-straps.md
@@ -45,7 +45,7 @@ This setup is extremely minimal. It's recommended to replace the buckle with a g
 #### Required Components
 
 ```admonish info
-5 meters of elastic band is generally enough for 6 straps for an average European XL-sized man.
+5 meters of elastic band are generally enough to make 6 straps for an average man wearing European size XL.
 ```
 
 | Component                                              | Listing Name                                                                                                                     | Color/Variant             | Link                                                                |
@@ -90,7 +90,7 @@ Same bare-bones and modular approach as V1, but it also requires a needle and th
 #### Required Components
 
 ```admonish info
-5 meters of elastic band is generally enough for 6 straps for an average European XL-sized man.
+5 meters of elastic band are generally enough to make 6 straps for an average man wearing European size XL.
 ```
 
 | Component                                              | Listing Name                                                                                                                     | Color/Variant             | Link                                                                |


### PR DESCRIPTION
Changed page:
<img width="1575" height="2398" alt="screencapture-localhost-3000-smol-slimes-hardware-smol-diy-set-cost-calculator-html-2025-10-03-22_58_30" src="https://github.com/user-attachments/assets/5ab5b6fb-0c63-461c-a641-35dd8c79853d" />
Before:
<img width="1575" height="1905" alt="screencapture-localhost-3000-smol-slimes-hardware-smol-diy-set-cost-calculator-html-2025-10-03-22_58_43" src="https://github.com/user-attachments/assets/95ee833e-3a36-4674-9364-d4cccb7ee2fe" />
