### PR TITLE
Rewrite Smol Pairing & Calibration guide for clarity and readability

### DIFF
--- a/src/smol-slimes/firmware/smol-pairing-and-calibration.md
+++ b/src/smol-slimes/firmware/smol-pairing-and-calibration.md
@@ -142,8 +142,8 @@ cat /etc/udev/rules.d/99-hid-dongle.rules
 * Reboot the tracker: `reboot` or press the **SW0** button.
 * Reboot the receiver: `reboot`.
 * Ensure the IMU is detected on the tracker: `info`.
-  * `IMU: ICM-45686` <-- Good
-  * `IMU: None` <-- Bad. Go back to the build stage to troubleshoot.
+  * Functioning: `IMU: ICM-45686`
+  * Non-Functioning/Not Detected: `IMU: None`
 
 ## Reference
 


### PR DESCRIPTION
Reorganised sections to make more sense logically: setup → pairing → calibration → firmware → troubleshooting → reference

Simpler and clearing wording, reduced repetition and wordy stuff

Added step by step instructions, improved titles, made formatting consistent, utilised admonish for tips and warnings, corrected grammar and typos etc.

Moved button and console commands to a reference section.