### PR TITLE
Updated SlimeVR101.md with up to date information

### DIFF
--- a/src/slimevr101.md
+++ b/src/slimevr101.md
@@ -50,7 +50,7 @@ Depending on how you plan to use FBT in VR, choose one of the following options:
       <td>Core Set</td>
       <td data-label="IMUs">6</td>
       <td data-label="Additional Trackers:">+ Extra Spine Tracker</td>
-      <td data-label="Expected Audience:">Users who want hip rotation</td>
+      <td data-label="Expected Audience:">Users who want hip rotation and increases accuracy for torso movement</td>
       <td>
         Adds an extra spine tracker on the hip for improved stability, especially when
         sitting, lying down, or bending over.


### PR DESCRIPTION
Clarified mounting locations for 5 and 6 tracker sets. Changed the Enhanced Core Set to be labelled as 6+2 instead of 5+3, in line with the current Crowdsupply listing for that set.