### PR TITLE
Change tracker firmware source to kounocom until SDK mess is fixed

### DIFF
--- a/src/smol-slimes/firmware/smol-pre-compiled-firmware.md
+++ b/src/smol-slimes/firmware/smol-pre-compiled-firmware.md
@@ -79,14 +79,14 @@ You only need the following if you are using precompiled firmware:
         <td>✅</td>
         <td>N/A</td>
         <td>
-          <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SPI_StackedSmol.uf2" target="_blank">Link</a>
+          <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SPI_StackedSmol.uf2" target="_blank">Link</a>
         </td>
       </tr>
       <tr>
         <td>✖️</td>
         <td>N/A</td>
         <td>
-          <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SPI_StackedSmol.uf2" target="_blank">Link</a> <sup style="font-size:0.6em">✅ recommended</sup>
+          <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SPI_StackedSmol.uf2" target="_blank">Link</a> <sup style="font-size:0.6em">✅ recommended</sup>
         </td>
       </tr>
       <tr>
@@ -94,14 +94,14 @@ You only need the following if you are using precompiled firmware:
         <td>✅</td>
         <td>N/A</td>
         <td>
-          <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_I2C_StackedSmol.uf2" target="_blank">Link</a>
+          <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_I2C_StackedSmol.uf2" target="_blank">Link</a>
         </td>
       </tr>
       <tr>
         <td>✖️</td>
         <td>N/A</td>
         <td>
-          <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_I2C_StackedSmol.uf2" target="_blank">Link</a>
+          <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_I2C_StackedSmol.uf2" target="_blank">Link</a>
         </td>
       </tr>
     </tbody>
@@ -114,14 +114,14 @@ You only need the following if you are using precompiled firmware:
         <td>✅</td>
         <td>N/A</td>
         <td>
-          <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoCLK_SPI_StackedSmol.uf2" target="_blank">Link</a>
+          <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoCLK_SPI_StackedSmol.uf2" target="_blank">Link</a>
         </td>
       </tr>
       <tr>
         <td>✖️</td>
         <td>N/A</td>
         <td>
-          <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoCLK_NoSleep_SPI_StackedSmol.uf2" target="_blank">Link</a>
+          <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoCLK_NoSleep_SPI_StackedSmol.uf2" target="_blank">Link</a>
         </td>
       </tr>
       <tr>
@@ -129,14 +129,14 @@ You only need the following if you are using precompiled firmware:
         <td>✅</td>
         <td>N/A</td>
         <td>
-          <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoCLK_I2C_StackedSmol.uf2" target="_blank">Link</a>
+          <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoCLK_I2C_StackedSmol.uf2" target="_blank">Link</a>
         </td>
       </tr>
       <tr>
         <td>✖️</td>
         <td>N/A</td>
         <td>
-          <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoCLK_NoSleep_I2C_StackedSmol.uf2" target="_blank">Link</a>
+          <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoCLK_NoSleep_I2C_StackedSmol.uf2" target="_blank">Link</a>
         </td>
       </tr>
     </tbody>
@@ -178,20 +178,20 @@ You only need the following if you are using precompiled firmware:
          <td rowspan="2">✖️</td>
          <td>✅</td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SPI_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SPI_ProMicro.uf2">Link</a>
          </td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_SPI_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_SPI_ProMicro.uf2">Link</a>
          </td>
       </tr>
       <tr>
          <!-- ProMicro, SPI, not stacked, no sleep -->
          <td>✖️</td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SPI_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SPI_ProMicro.uf2">Link</a>
          </td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_NoSleep_SPI_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_NoSleep_SPI_ProMicro.uf2">Link</a>
          </td>
       </tr>
       <tr>
@@ -199,20 +199,20 @@ You only need the following if you are using precompiled firmware:
          <td rowspan="2">✅</td>
          <td>✅</td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_CLK_SPI_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_CLK_SPI_ProMicro.uf2">Link</a>
          </td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_CLK_SPI_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_CLK_SPI_ProMicro.uf2">Link</a>
          </td>
       </tr>
       <tr>
          <!-- ProMicro, SPI, not stacked, clk, no sleep -->
          <td>✖️</td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleepCLK_SPI_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleepCLK_SPI_ProMicro.uf2">Link</a>
          </td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_NoSleepCLK_SPI_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_NoSleepCLK_SPI_ProMicro.uf2">Link</a>
          </td>
       </tr>
       <!-- ProMicro, I2C, not stacked -->
@@ -221,38 +221,38 @@ You only need the following if you are using precompiled firmware:
          <td rowspan="2">✖️</td>
          <td>✅</td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_I2C_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_I2C_ProMicro.uf2">Link</a>
          </td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_I2C_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_I2C_ProMicro.uf2">Link</a>
          </td>
       </tr>
       <tr>
          <td>✖️</td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_I2C_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_I2C_ProMicro.uf2">Link</a>
          </td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_NoSleep_I2C_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_NoSleep_I2C_ProMicro.uf2">Link</a>
          </td>
       </tr>
       <tr>
          <td rowspan="2">✅</td>
          <td>✅</td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_CLK_I2C_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_CLK_I2C_ProMicro.uf2">Link</a>
          </td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_CLK_I2C_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_CLK_I2C_ProMicro.uf2">Link</a>
          </td>
       </tr>
       <tr>
          <td>✖️</td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleepCLK_I2C_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleepCLK_I2C_ProMicro.uf2">Link</a>
          </td>
          <td>
-            <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_NoSleepCLK_I2C_ProMicro.uf2">Link</a>
+            <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_NoSleepCLK_I2C_ProMicro.uf2">Link</a>
          </td>
       </tr>
       </tbody>
@@ -264,38 +264,38 @@ You only need the following if you are using precompiled firmware:
             <td rowspan="2">✖️</td>
             <td>✅</td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_XIAO.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_XIAO.uf2">Link</a>
             </td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_XIAO.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_XIAO.uf2">Link</a>
             </td>
          </tr>
          <tr>
             <td>✖️</td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_XIAO.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_XIAO.uf2">Link</a>
             </td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_NoSleep_XIAO.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_NoSleep_XIAO.uf2">Link</a>
             </td>
          </tr>
          <tr>
             <td rowspan="2">✅</td>
             <td>✅</td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_CLK_XIAO.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_CLK_XIAO.uf2">Link</a>
             </td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_CLK_XIAO.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_CLK_XIAO.uf2">Link</a>
             </td>
          </tr>
          <tr>
             <td>✖️</td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleepCLK_XIAO.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleepCLK_XIAO.uf2">Link</a>
             </td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_NoSleepCLK_XIAO.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SW0_NoSleepCLK_XIAO.uf2">Link</a>
             </td>
          </tr>
       </tbody>
@@ -307,14 +307,14 @@ You only need the following if you are using precompiled firmware:
             <td rowspan="2">✅</td>
             <td>✅</td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_R3.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_R3.uf2">Link</a>
             </td>
             <td>N/A</td>
          </tr>
          <tr>
             <td>✖️</td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_R3.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_R3.uf2">Link</a>
             </td>
             <td>N/A</td>
          </tr>
@@ -327,14 +327,14 @@ You only need the following if you are using precompiled firmware:
             <td rowspan="2">✅</td>
             <td>✅</td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SlimevrMini.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SlimevrMini.uf2">Link</a>
             </td>
             <td>N/A</td>
          </tr>
          <tr>
             <td>✖️</td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SlimevrMini.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SlimevrMini.uf2">Link</a>
             </td>
             <td>N/A</td>
          </tr>
@@ -347,14 +347,14 @@ You only need the following if you are using precompiled firmware:
             <td rowspan="2">✅</td>
             <td>✅</td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SlimevrMini2.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_SlimevrMini2.uf2">Link</a>
             </td>
             <td>N/A</td>
          </tr>
          <tr>
             <td>✖️</td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SlimevrMini2.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SlimevrMini2.uf2">Link</a>
             </td>
             <td>N/A</td>
          </tr>
@@ -367,7 +367,7 @@ You only need the following if you are using precompiled firmware:
             <td>✅</td>
             <td>✖️</td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SlimevrMini3_R6.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SlimevrMini3_R6.uf2">Link</a>
             </td>
             <td>N/A</td>
          </tr>
@@ -380,7 +380,7 @@ You only need the following if you are using precompiled firmware:
             <td>✅</td>
             <td>✖️</td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SlimevrMini3_R7.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SlimevrMini3_R7.uf2">Link</a>
             </td>
             <td>N/A</td>
          </tr>
@@ -392,7 +392,7 @@ You only need the following if you are using precompiled firmware:
             <td>✖️</td>
             <td>N/A</td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SlimevrMini4.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SlimevrMini4.uf2">Link</a>
             </td>
          </tr>
          <!-- Butterfly (P4, R9) -->
@@ -403,7 +403,7 @@ You only need the following if you are using precompiled firmware:
             <td>✖️</td>
             <td>N/A</td>
             <td>
-               <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SlimevrMini4R9.uf2">Link</a>
+               <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_SlimevrMini4R9.uf2">Link</a>
             </td>
          </tr>
       </tbody>
@@ -447,14 +447,14 @@ You only need the following if you are using precompiled firmware:
         <td>✅</td>
         <td>N/A</td>
         <td>
-          <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_Chrysalis_ProMicro.uf2" target="_blank">Link</a>
+          <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_Chrysalis_ProMicro.uf2" target="_blank">Link</a>
         </td>
       </tr>
       <tr>
         <td>✖️</td>
         <td>N/A</td>
         <td>
-          <a href="https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_Chrysalis_ProMicro.uf2" target="_blank">Link</a>
+          <a href="https://github.com/kounocom/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Tracker_NoSleep_Chrysalis_ProMicro.uf2" target="_blank">Link</a>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
Temporarily changes the source of smol tracker firmware builds from @ShineBrightMeow to me, since Shine's workflow uses v3.2.0 as the SDK which breaks some things with trackers

(at the time of this PR being made, the workflow hasn't finished running so not all links are working)