### PR TITLE
Add INT pin warning

### DIFF
--- a/src/smol-slimes/hardware/smol-tracker.md
+++ b/src/smol-slimes/hardware/smol-tracker.md
@@ -140,7 +140,7 @@ Buttons and slide switches are recommended but not required. Buttons can be adde
 ></div>
 
 ```admonish warning
-INT pin is required even if you're not running sleep.
+The INT pin is required, even if the tracker is not sleep enabled.
 ```
 
 ## Tracker Parts


### PR DESCRIPTION
Clarified the INT pin is non optional even for non-sleep firmware