### PR TITLE
Add ProMicro nRF52840 black

### DIFF
--- a/src/smol-slimes/hardware/smol-tracker.md
+++ b/src/smol-slimes/hardware/smol-tracker.md
@@ -162,8 +162,7 @@ The INT pin is required, even if the tracker is not sleep enabled.
           <span id="ProMicro"> ProMicro nRF52840 </span>
         </td>
         <td>
-          A clone of the <strong>nice!nano</strong> board. Cheapest option
-          overall. <br />
+          A clone of the <strong>nice!nano</strong> board. Affordable and good quality.
           Signal strength can be improved with antenna mod.
         </td>
         <td>
@@ -174,6 +173,26 @@ The INT pin is required, even if the tracker is not sleep enabled.
             <li>
               <a href="https://pl.aliexpress.com/item/1005007738886550.html">
                 AliExpress TENSTAR 2pcs pack
+              </a>
+            </li>
+          </ul>
+        </td>
+      </tr>
+	  <tr>
+        <td>
+          <span id="ProMicroB"> ProMicro nRF52840 in black </span>
+        </td>
+        <td>
+          A popular <strong>nice!nano</strong> clone. An even more affordable version.
+		  It may be necessary to apply the <a href="https://github.com/joric/nrfmicro/wiki/Alternatives#supermini-issue-fixes">SuperMini Issue Fixes</a>.
+          Signal strength can be improved with antenna mod.
+        </td>
+        <td>
+          Available on AliExpress with <code>ProMicro</code> branding.
+          <ul>
+            <li>
+              <a href="https://aliexpress.com/item/1005007266112508.html">
+                AliExpress NRF52840 Development Board
               </a>
             </li>
           </ul>
@@ -197,6 +216,11 @@ The INT pin is required, even if the tracker is not sleep enabled.
     </tbody>
   </table>
 </div>
+
+```admonish warning
+A wrong pull-up resistor on black nRF52840 boards can mean up to 80% worse battery drain while powered off.
+You can also remove the resistor.
+```
 
 ### 🧭 Inertial Measurement Units
 


### PR DESCRIPTION
I've added the black ProMicro nRF52840 boards to the table. Originally I just wanted to add a note about the SuperMini Issue Fixes, but this should be better. The black boards show up very often, simply because they are significantly cheaper.

I've therefore also added a warning below the table that the black boards with a wrong pull-up resistor have significantly worse power-off battery drain, and that the resistor can be removed.

This way nobody should fall into the trap of having higher power consumption with the black boards. The purchase decision is of course not up to us.

@Devs please verify the removal, based on my testing and the notes in the SuperMini Issue Fixes, it can simply be taken out. I also haven't found any issues in the SlimeVR code.