### PR TITLE
Restructure DIY calculator with modular JS, primary/extension tracker logic, and updated UI

### DIFF
--- a/src/assets/js/diy-calculator/components-data.js
+++ b/src/assets/js/diy-calculator/components-data.js
@@ -1,0 +1,435 @@
+const primaryCountMap = { 5: 5, 6: 6, 8: 6, 10: 8 };
+
+export function primaryTrackerCount(set) {
+  return primaryCountMap[set] !== undefined ? primaryCountMap[set] : set;
+}
+
+export function extensionCount(set) {
+  return set - primaryTrackerCount(set);
+}
+
+export function physicalTrackerCount(set) {
+  return set;
+}
+
+export const componentCategories = [
+  {
+    name: 'Microcontroller',
+    choices: [
+      {
+        name: 'Wemos D1 Mini (AliExpress)',
+        description: 'ESP8266 dev board. Standard choice for DIY SlimeVR trackers.',
+        amount: (set) => primaryTrackerCount(set),
+        cost: () => 1.85,
+        costAll: (set) => primaryTrackerCount(set) * 1.85 + 2.53,
+        links: '\
+            <a href="https://www.aliexpress.com/wholesale?SearchText=D1+mini">AliExpress Wemos D1 Mini</a><br/>\
+            <span>$1.85 per board, plus $2.53 shipping.</span>',
+      },
+    ],
+  },
+  {
+    name: 'IMU',
+    choices: [
+      {
+        name: '🟢 ICM-45686 (SlimeVR shop)',
+        description: 'Best performance option.',
+        amount: (set) => set,
+        cost: () => 6.70,
+        costAll: (set) => set * 6.70 + 6.70,
+        links: '\
+            <a href="https://shop.slimevr.dev/products/slimevr-mumo-breakout-module-v1-icm-45686-qmc6309">SlimeVR Mumo Breakout Module V1 (ICM-45686 + QMC6309)</a><br/>\
+            <span>$6.70 per IMU. Cost includes one extra spare (+$6.70).</span>',
+      },
+      {
+        name: '🟢 LSM6DSV (Moffshop)',
+        description: 'Great performance from Moffshop.',
+        amount: (set) => set,
+        cost: () => 8.93,
+        costAll: (set) => set * 8.93 + 5.58,
+        links: '\
+            <a href="https://moffshop.deyta.de/products/lsm6dsv-module" target="_blank">Moffshop LSM6DSV</a><br/>\
+            <span>$8.93 per IMU. Cost includes one extra spare (+$5.58).</span>',
+      },
+      {
+        name: '🟢 LSM6DSR (AliExpress)',
+        description: 'Budget option.',
+        amount: (set) => set,
+        cost: () => 3.35,
+        costAll: (set) => set * 3.35 + 6.70,
+        links: '\
+            <a href="https://www.aliexpress.com/wholesale?SearchText=LSM6DSR">AliExpress LSM6DSR</a><br/>\
+            <span>$3.35 per IMU. Cost includes one extra spare (+$6.70).</span>',
+      },
+    ],
+  },
+  {
+    name: 'Batteries',
+    choices: [
+      {
+        name: '1800 mAh 804040 Li-Po (AliExpress)',
+        description: 'Large capacity. One per primary tracker.',
+        amount: (set) => primaryTrackerCount(set),
+        cost: () => 1.67,
+        costAll: (set) => primaryTrackerCount(set) * 1.67,
+        links: '\
+            <a href="https://www.aliexpress.com/item/1005009612692951.html">804040 1800mAh 10pk 2 wires (AliExpress)</a><br/>\
+            <span>$16.74 per 10-pack ($1.67 per battery).</span>',
+      },
+      {
+        name: '1200 mAh 903052 Li-Po - 5 pcs (Amazon)',
+        description: 'Buy 1 pack for up to 5 primary trackers, 2 for 6+.',
+        amount: (set) => Math.ceil(primaryTrackerCount(set) / 5),
+        cost: () => 22.99,
+        costAll: (set) => Math.ceil(primaryTrackerCount(set) / 5) * 22.99,
+        links: '\
+            <a href="https://www.amazon.com/dp/B088YKPZ9D/">Amazon Li-Po Batteries</a><br/>\
+            <span>$22.99 per 5-pack.</span>',
+      },
+      {
+        name: 'Generic 18650 (AliExpress)',
+        description: 'Per primary tracker. Requires holder. Buyer beware: rated capacities may be inaccurate.',
+        amount: (set) => primaryTrackerCount(set),
+        cost: () => 3 + 0.27,
+        costAll: (set) => primaryTrackerCount(set) * (3 + 0.27) + 1.89,
+        links: '\
+            <a href="https://www.aliexpress.com/wholesale?SearchText=18650+cell">AliExpress 18650 cell</a> and \
+            <a href="https://www.aliexpress.us/item/3256801521575042.html">AliExpress (X4 Slot)</a><br/>\
+            <span>$3 per cell + $0.27 holder, plus $1.89 shipping.</span>',
+      },
+      {
+        name: 'Sourced elsewhere',
+        amount: () => 0,
+        cost: () => 0,
+        costAll: () => 0,
+        links: '',
+      },
+    ],
+  },
+  {
+    name: 'Charging Board',
+    choices: [
+      {
+        name: 'TP4056 USB charging board (AliExpress)',
+        description: 'One per primary tracker.',
+        amount: (set) => primaryTrackerCount(set),
+        cost: () => 0.36,
+        costAll: (set) => primaryTrackerCount(set) * 0.36 + 2.07,
+        links: '\
+            <a href="https://www.aliexpress.com/item/32649780468.html">AliExpress (18650 mini / type-c / micro)</a><br/>\
+            <span>$0.36 per board, plus $2.07 shipping.</span>',
+      },
+      {
+        name: 'TP4056 USB charging board - 10 pcs (Amazon)',
+        description: 'Enough for 10 primary trackers.',
+        amount: () => 1,
+        cost: () => 8.19,
+        costAll: () => 8.19,
+        links: '\
+            <a href="https://www.amazon.com/dp/B08DNK398S">Amazon TP4056</a><br/>\
+            <span>$8.19 for 10pcs.</span>',
+      },
+      {
+        name: 'Sourced elsewhere',
+        amount: () => 0,
+        cost: () => 0,
+        costAll: () => 0,
+        links: '',
+      },
+    ],
+  },
+  {
+    name: 'Power Switches',
+    choices: [
+      {
+        name: 'SS22F32 switches - 10 pcs (AliExpress)',
+        description: '',
+        amount: () => 1,
+        cost: () => 1.97,
+        costAll: () => 1.97,
+        links: '\
+            <a href="https://www.aliexpress.com/item/32975535599.html">AliExpress</a><br/>\
+            <span>$1.97 for 10pcs.</span>',
+      },
+      {
+        name: 'SS22F32 switches - 10 pcs (Alt) (Amazon)',
+        description: '',
+        amount: () => 1,
+        cost: () => 7.99,
+        costAll: () => 7.99,
+        links: '\
+            <a href="https://www.amazon.com/dp/B083RBS2RT">Amazon SS22F32 switches</a><br/>\
+            <span>$7.99 for 10pcs.</span>',
+      },
+      {
+        name: 'Sourced elsewhere',
+        amount: () => 0,
+        cost: () => 0,
+        costAll: () => 0,
+        links: '',
+      },
+    ],
+  },
+  {
+    name: 'Diodes',
+    choices: [
+      {
+        name: '1N5817 diodes - 50 pcs (AliExpress)',
+        description: 'Optional for battery protection.',
+        amount: () => 1,
+        cost: () => 0.62,
+        costAll: () => 0.62 + 2.21,
+        links: '\
+            <a href="https://www.aliexpress.us/item/3256801365779334.html">AliExpress (1N5817)</a><br/>\
+            <span>$0.62 for 50pcs, plus $2.21 shipping.</span>',
+      },
+      {
+        name: '1N5817 diodes - 100 pcs (Amazon)',
+        description: 'Optional for battery protection.',
+        amount: () => 1,
+        cost: () => 5.99,
+        costAll: () => 5.99,
+        links: '\
+            <a href="https://www.amazon.com/dp/B079KDQQPD">Amazon 1N5817 diodes</a><br/>\
+            <span>$5.99 for 100pcs.</span>',
+      },
+      {
+        name: 'Sourced elsewhere',
+        amount: () => 0,
+        cost: () => 0,
+        costAll: () => 0,
+        links: '',
+      },
+    ],
+  },
+  {
+    name: 'Resistors',
+    choices: [
+      {
+        name: '180K ohm resistors - 100 pcs (AliExpress)',
+        description: 'Optional for battery percentage reporting.',
+        amount: () => 1,
+        cost: () => 1.96,
+        costAll: () => 1.96 + 1.29,
+        links: '\
+            <a href="https://www.aliexpress.us/item/3256802808441054.html">AliExpress (100pcs 180K ohms)</a><br/>\
+            <span>$1.96 for 100pcs, plus $1.29 shipping.</span>',
+      },
+      {
+        name: '180K ohm resistors - 100 pcs (Alt) (Amazon)',
+        description: 'Optional for battery percentage reporting.',
+        amount: () => 1,
+        cost: () => 4.99,
+        costAll: () => 4.99,
+        links: '\
+            <a href="https://www.amazon.com/dp/B07HDFCNXB">Amazon 180K ohm resistors</a><br/>\
+            <span>$4.99 for 100pcs.</span>',
+      },
+      {
+        name: 'Sourced elsewhere',
+        defaultSelected: true,
+        amount: () => 0,
+        cost: () => 0,
+        costAll: () => 0,
+        links: '',
+      },
+    ],
+  },
+  {
+    name: 'Carrier Board Options',
+    choices: [
+      {
+        name: 'PCB chosen from cases page',
+        description: 'Order 10 PCBs from a PCB fab.',
+        amount: () => 10,
+        cost: () => 0.50,
+        costAll: () => 5,
+        links: '\
+            <a href="https://docs.slimevr.dev/diy/cases.html">Cases page here</a><br/>\
+            <span>$0.50 per PCB, $5 for 10pcs.</span>',
+      },
+      {
+        name: '24-26 AWG Wire, No PCB (Not Recommended) (AliExpress)',
+        description: 'Point-to-point wiring instead of PCB.',
+        amount: () => 1,
+        cost: () => 1.85,
+        costAll: () => 1.85 + 1.68,
+        links: '\
+            <a href="https://www.aliexpress.com/item/1005002632016529.html">AliExpress (22 AWG, 2m)</a><br/>\
+            <span>$1.85 for wire, plus $1.68 shipping.</span>',
+      },
+      {
+        name: '26AWG Wire, No PCB (Not Recommended) (Amazon)',
+        description: '10m spools, 6-pack.',
+        amount: () => 1,
+        cost: () => 14.99,
+        costAll: () => 14.99,
+        links: '\
+            <a href="https://www.amazon.com/dp/B07G2LRX68">Amazon 26 AWG, 10m spools</a><br/>\
+            <span>$14.99 for 6 spools.</span>',
+      },
+      {
+        name: 'Sourced elsewhere',
+        amount: () => 0,
+        cost: () => 0,
+        costAll: () => 0,
+        links: '',
+      },
+    ],
+  },
+  {
+    name: 'Wiring for Extensions',
+    hideFor5Set: true,
+    choices: [
+      {
+        name: 'JST connectors - 5 pin 5 pcs (AliExpress)',
+        description: 'Optional for removable extensions. 2 connectors per extension.',
+        amount: (set) => Math.ceil(extensionCount(set) * 2 / 5),
+        cost: () => 3,
+        costAll: (set) => Math.ceil(extensionCount(set) * 2 / 5) * 3 + 3.96,
+        links: '\
+            <a href="https://www.aliexpress.us/item/3256803829669959.html">AliExpress JST connectors</a><br/>\
+            <span>$3 for 5pcs, plus $3.96 shipping.</span>',
+      },
+      {
+        name: 'JST connectors - 5 pin 20 pcs (Amazon)',
+        description: 'Optional for removable extensions. 2 connectors per extension.',
+        amount: (set) => Math.ceil(extensionCount(set) * 2 / 20),
+        cost: () => 12.98,
+        costAll: (set) => Math.ceil(extensionCount(set) * 2 / 20) * 12.98,
+        links: '\
+            <a href="https://www.amazon.com/dp/B075K6N7DF">Amazon JST connectors</a><br/>\
+            <span>$12.98 for 20pcs.</span>',
+      },
+      {
+        name: 'SlimeVR Extension Cables Deluxe Set (SlimeVR shop)',
+        description: 'Pre-made V3 cables from official store. 6 foot + 2 hip + 2 arm. 10 cables, one per extension.',
+        amount: (set) => Math.ceil(extensionCount(set) / 10),
+        cost: () => 4.50,
+        costAll: (set) => Math.ceil(extensionCount(set) / 10) * 4.50,
+        links: '\
+            <a href="https://shop.slimevr.dev/products/slimevr-extension-cables-deluxe-set">SlimeVR Shop (Deluxe Set)</a><br/>\
+            <span>~$4.50 for 10 cables.</span>',
+      },
+      {
+        name: 'SlimeVR Extension Cables Full-Body Set (SlimeVR shop)',
+        description: 'Pre-made V3 cables from official store. 4 foot + 2 hip. 6 cables, one per extension.',
+        amount: (set) => Math.ceil(extensionCount(set) / 6),
+        cost: () => 3.00,
+        costAll: (set) => Math.ceil(extensionCount(set) / 6) * 3.00,
+        links: '\
+            <a href="https://shop.slimevr.dev/products/slimevr-extension-cables-full-body-set">SlimeVR Shop (Full-Body Set)</a><br/>\
+            <span>~$3.00 for 6 cables.</span>',
+      },
+      {
+        name: 'Sourced elsewhere',
+        amount: () => 0,
+        cost: () => 0,
+        costAll: () => 0,
+        links: '',
+      },
+    ],
+  },
+  {
+    name: 'Cases',
+    choices: [
+      {
+        name: '3D printed yourself, approximate $',
+        description: '',
+        amount: (set) => set,
+        cost: () => 2,
+        costAll: (set) => set * 2,
+        links: '\
+            <span>You make your own cases!<br/><br/>$2 per case (3D print material estimate).</span>',
+      },
+      {
+        name: 'Amazon cases - 6 pcs (Amazon)',
+        description: '1 pack for up to 6 trackers, 2 for 7+.',
+        amount: (set) => Math.ceil(set / 6),
+        cost: () => 7.49,
+        costAll: (set) => Math.ceil(set / 6) * 7.49,
+        links: '\
+            <a href="https://www.amazon.com/dp/B08T97JD6Z">Amazon cases</a><br/>\
+            <span>$7.49 per 6-pack.</span>',
+      },
+      {
+        name: 'Sourced elsewhere',
+        amount: () => 0,
+        cost: () => 0,
+        costAll: () => 0,
+        links: '',
+      },
+    ],
+  },
+  {
+    name: 'Straps',
+    choices: [
+      {
+        name: '🟡 Generic AliExpress straps - 6 pcs (AliExpress)',
+        description: '1 pack for fewer than 6 trackers, 2 for 6+.',
+        amount: (set) => set < 6 ? 1 : 2,
+        cost: () => 5,
+        costAll: (set) => (set < 6 ? 1 : 2) * 5 + 2.77,
+        links: '\
+            <a href="https://aliexpress.com/item/1005001908740631.html">AliExpress straps</a><br/>\
+            <span>$5 per 6-pack, plus $2.77 shipping.</span>',
+      },
+      {
+        name: '🟡 Generic Amazon straps - 5 pcs (Amazon)',
+        description: '1 pack for under 5 trackers, 2 for 5+.',
+        amount: (set) => set < 5 ? 1 : 2,
+        cost: () => 9.00,
+        costAll: (set) => (set < 5 ? 1 : 2) * 9.00,
+        links: '\
+            <a href="https://www.amazon.com/dp/B09T5YDMTR/">Amazon straps</a><br/>\
+            <span>$9 per 5-pack.</span>',
+      },
+      {
+        name: '🟢 VYRO VR Silicone Straps',
+        amount: (set) => Math.ceil(set / 10),
+        cost: () => 27.46,
+        costAll: (set) => Math.ceil(set / 10) * 27.46,
+        links: '\
+          <a href="https://vyrovr.com/products/10-slimevr-compatible-silicone-backed-30mm-straps" target="_blank">VYRO VR Silicone Straps</a><br/>\
+          10-pack: 2x30cm + 4x35cm + 2x50cm + 2x110cm\
+          <ul>\
+            <li>30cm (~12"): ankles, arms</li>\
+            <li>50cm (~20"): thighs, hip</li>\
+            <li>110cm (~43"): chest, waist</li>\
+          </ul>',
+      },
+      {
+        name: '🟢 VYRO VR Comfort Strap Bundle',
+        amount: () => 1,
+        cost: (set) => {
+          if (set <= 6) return 109;
+          if (set <= 8) return 114;
+          return 139;
+        },
+        costAll: (set) => {
+          if (set <= 6) return 109;
+          if (set <= 8) return 114;
+          if (set <= 10) return 139;
+          return 278;
+        },
+        links: '\
+          <a href="https://vyrovr.com/products/vyro-vr-comfort-strap-bundles" target="_blank">VYRO VR Comfort Strap Bundles</a><br/>\
+          <br/>\
+          Variants:\
+          <ul>\
+            <li>Core: 1 Chest + 1 Hip + 2 Thigh + 2 Ankles + 3 Extension Brackets: $109</li>\
+            <li>Advanced: Core + 2 extra basic straps for feet trackers: $114</li>\
+            <li>Full Body: Core + 2 extra basic straps + 2 extra Comfort straps for arms: $139</li>\
+          </ul>',
+      },
+      {
+        name: 'Sourced elsewhere',
+        defaultSelected: true,
+        amount: () => 0,
+        cost: () => 0,
+        costAll: () => 0,
+        links: '',
+      },
+    ],
+  },
+];

--- a/src/assets/js/diy-calculator/components-data.js
+++ b/src/assets/js/diy-calculator/components-data.js
@@ -365,40 +365,6 @@ export const componentCategories = [
     name: 'Straps',
     choices: [
       {
-        name: '🟡 Generic AliExpress straps - 6 pcs (AliExpress)',
-        description: '1 pack for fewer than 6 trackers, 2 for 6+.',
-        amount: (set) => set < 6 ? 1 : 2,
-        cost: () => 5,
-        costAll: (set) => (set < 6 ? 1 : 2) * 5 + 2.77,
-        links: '\
-            <a href="https://aliexpress.com/item/1005001908740631.html">AliExpress straps</a><br/>\
-            <span>$5 per 6-pack, plus $2.77 shipping.</span>',
-      },
-      {
-        name: '🟡 Generic Amazon straps - 5 pcs (Amazon)',
-        description: '1 pack for under 5 trackers, 2 for 5+.',
-        amount: (set) => set < 5 ? 1 : 2,
-        cost: () => 9.00,
-        costAll: (set) => (set < 5 ? 1 : 2) * 9.00,
-        links: '\
-            <a href="https://www.amazon.com/dp/B09T5YDMTR/">Amazon straps</a><br/>\
-            <span>$9 per 5-pack.</span>',
-      },
-      {
-        name: '🟢 VYRO VR Silicone Straps',
-        amount: (set) => Math.ceil(set / 10),
-        cost: () => 27.46,
-        costAll: (set) => Math.ceil(set / 10) * 27.46,
-        links: '\
-          <a href="https://vyrovr.com/products/10-slimevr-compatible-silicone-backed-30mm-straps" target="_blank">VYRO VR Silicone Straps</a><br/>\
-          10-pack: 2x30cm + 4x35cm + 2x50cm + 2x110cm\
-          <ul>\
-            <li>30cm (~12"): ankles, arms</li>\
-            <li>50cm (~20"): thighs, hip</li>\
-            <li>110cm (~43"): chest, waist</li>\
-          </ul>',
-      },
-      {
         name: '🟢 VYRO VR Comfort Strap Bundle',
         amount: () => 1,
         cost: (set) => {
@@ -421,6 +387,41 @@ export const componentCategories = [
             <li>Advanced: Core + 2 extra basic straps for feet trackers: $114</li>\
             <li>Full Body: Core + 2 extra basic straps + 2 extra Comfort straps for arms: $139</li>\
           </ul>',
+      },
+      {
+        name: '🟡 VYRO VR Silicone Straps',
+        amount: (set) => Math.ceil(set / 10),
+        cost: () => 27.46,
+        costAll: (set) => Math.ceil(set / 10) * 27.46,
+        links: '\
+          <a href="https://vyrovr.com/products/10-slimevr-compatible-silicone-backed-30mm-straps" target="_blank">VYRO VR Silicone Straps</a><br/>\
+          10-pack: 2x30cm + 4x35cm + 2x50cm + 2x110cm\
+          <ul>\
+            <li>30cm (~12"): ankles, arms</li>\
+            <li>50cm (~20"): thighs, hip</li>\
+            <li>110cm (~43"): chest, waist</li>\
+          </ul><br/>\
+          <span>Add GoPro style chest strap to improve set.</span>',
+      },
+      {
+        name: '🟡 Generic AliExpress straps - 6 pcs (AliExpress)',
+        description: '1 pack for fewer than 6 trackers, 2 for 6+.',
+        amount: (set) => set < 6 ? 1 : 2,
+        cost: () => 5,
+        costAll: (set) => (set < 6 ? 1 : 2) * 5 + 2.77,
+        links: '\
+            <a href="https://aliexpress.com/item/1005001908740631.html">AliExpress straps</a><br/>\
+            <span>$5 per 6-pack, plus $2.77 shipping.</span>',
+      },
+      {
+        name: '🟡 Generic Amazon straps - 5 pcs (Amazon)',
+        description: '1 pack for under 5 trackers, 2 for 5+.',
+        amount: (set) => set < 5 ? 1 : 2,
+        cost: () => 9.00,
+        costAll: (set) => (set < 5 ? 1 : 2) * 9.00,
+        links: '\
+            <a href="https://www.amazon.com/dp/B09T5YDMTR/">Amazon straps</a><br/>\
+            <span>$9 per 5-pack.</span>',
       },
       {
         name: 'Sourced elsewhere',

--- a/src/assets/js/diy-calculator/components-data.test.js
+++ b/src/assets/js/diy-calculator/components-data.test.js
@@ -1,0 +1,375 @@
+import { describe, it, expect } from 'vitest';
+import { componentCategories, physicalTrackerCount, primaryTrackerCount, extensionCount } from './components-data.js';
+
+const SET = { LOWER: 5, CORE: 6, ENHANCED: 8, FULL: 10 };
+
+function cat(name) {
+  return componentCategories.find(c => c.name === name);
+}
+function choice(category, index) {
+  return cat(category).choices[index];
+}
+
+describe('primaryTrackerCount', () => {
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${5}
+    ${SET.CORE} | ${6}
+    ${SET.ENHANCED}| ${6}
+    ${SET.FULL} | ${8}
+  `('returns $expected for set=$set', ({ set, expected }) => {
+    expect(primaryTrackerCount(set)).toBe(expected);
+  });
+});
+
+describe('extensionCount', () => {
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${0}
+    ${SET.CORE} | ${0}
+    ${SET.ENHANCED}| ${2}
+    ${SET.FULL} | ${2}
+  `('returns $expected for set=$set', ({ set, expected }) => {
+    expect(extensionCount(set)).toBe(expected);
+  });
+});
+
+describe('physicalTrackerCount', () => {
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${SET.LOWER}
+    ${SET.CORE} | ${SET.CORE}
+    ${SET.ENHANCED}| ${SET.ENHANCED}
+    ${SET.FULL} | ${SET.FULL}
+  `('returns $expected for set=$set', ({ set, expected }) => {
+    expect(physicalTrackerCount(set)).toBe(expected);
+  });
+});
+
+describe('Microcontroller', () => {
+  const c = choice('Microcontroller', 0);
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${5}
+    ${SET.CORE} | ${6}
+    ${SET.ENHANCED}| ${6}
+    ${SET.FULL} | ${8}
+  `('$expected boards for $set IMUs', ({ set, expected }) => {
+    expect(c.amount(set)).toBe(expected);
+  });
+});
+
+describe('IMU', () => {
+  for (let i = 0; i < 3; i++) {
+    const c = choice('IMU', i);
+    it.each`
+      set          | expected
+      ${SET.LOWER}| ${SET.LOWER}
+      ${SET.CORE} | ${SET.CORE}
+      ${SET.ENHANCED}| ${SET.ENHANCED}
+      ${SET.FULL} | ${SET.FULL}
+    `(`${c.name}: $expected IMUs for $set trackers`, ({ set, expected }) => {
+      expect(c.amount(set)).toBe(expected);
+    });
+  }
+});
+
+describe('Batteries', () => {
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${5}
+    ${SET.CORE} | ${6}
+    ${SET.ENHANCED}| ${6}
+    ${SET.FULL} | ${8}
+  `('1800 mAh 804040: $expected batteries for $set trackers', ({ set, expected }) => {
+    expect(choice('Batteries', 0).amount(set)).toBe(expected);
+  });
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${1}
+    ${SET.CORE} | ${2}
+    ${SET.ENHANCED}| ${2}
+    ${SET.FULL} | ${2}
+  `('1200 mAh 5-pack: $expected packs for $set trackers', ({ set, expected }) => {
+    expect(choice('Batteries', 1).amount(set)).toBe(expected);
+  });
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${5}
+    ${SET.CORE} | ${6}
+    ${SET.ENHANCED}| ${6}
+    ${SET.FULL} | ${8}
+  `('Generic 18650: $expected for $set trackers', ({ set, expected }) => {
+    expect(choice('Batteries', 2).amount(set)).toBe(expected);
+  });
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${0}
+    ${SET.CORE} | ${0}
+    ${SET.ENHANCED}| ${0}
+    ${SET.FULL} | ${0}
+  `('Sourced elsewhere: $expected for $set trackers', ({ set, expected }) => {
+    expect(choice('Batteries', 3).amount(set)).toBe(expected);
+  });
+});
+
+describe('Charging Board', () => {
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${5}
+    ${SET.CORE} | ${6}
+    ${SET.ENHANCED}| ${6}
+    ${SET.FULL} | ${8}
+  `('TP4056 single: $expected boards for $set trackers', ({ set, expected }) => {
+    expect(choice('Charging Board', 0).amount(set)).toBe(expected);
+  });
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${1}
+    ${SET.CORE} | ${1}
+    ${SET.ENHANCED}| ${1}
+    ${SET.FULL} | ${1}
+  `('TP4056 10-pack: $expected pack for $set trackers', ({ set, expected }) => {
+    expect(choice('Charging Board', 1).amount(set)).toBe(expected);
+  });
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${0}
+    ${SET.CORE} | ${0}
+    ${SET.ENHANCED}| ${0}
+    ${SET.FULL} | ${0}
+  `('Sourced elsewhere: $expected for $set trackers', ({ set, expected }) => {
+    expect(choice('Charging Board', 2).amount(set)).toBe(expected);
+  });
+});
+
+describe('Power Switches', () => {
+  for (let i = 0; i < 2; i++) {
+    const c = choice('Power Switches', i);
+    it.each`
+      set          | expected
+      ${SET.LOWER}| ${1}
+      ${SET.CORE} | ${1}
+      ${SET.ENHANCED}| ${1}
+      ${SET.FULL} | ${1}
+    `(`${c.name}: $expected pack for $set trackers`, ({ set, expected }) => {
+      expect(c.amount(set)).toBe(expected);
+    });
+  }
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${0}
+    ${SET.CORE} | ${0}
+    ${SET.ENHANCED}| ${0}
+    ${SET.FULL} | ${0}
+  `('Sourced elsewhere: $expected for $set trackers', ({ set, expected }) => {
+    expect(choice('Power Switches', 2).amount(set)).toBe(expected);
+  });
+});
+
+describe('Diodes', () => {
+  for (let i = 0; i < 2; i++) {
+    const c = choice('Diodes', i);
+    it.each`
+      set          | expected
+      ${SET.LOWER}| ${1}
+      ${SET.CORE} | ${1}
+      ${SET.ENHANCED}| ${1}
+      ${SET.FULL} | ${1}
+    `(`${c.name}: $expected pack for $set trackers`, ({ set, expected }) => {
+      expect(c.amount(set)).toBe(expected);
+    });
+  }
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${0}
+    ${SET.CORE} | ${0}
+    ${SET.ENHANCED}| ${0}
+    ${SET.FULL} | ${0}
+  `('Sourced elsewhere: $expected for $set trackers', ({ set, expected }) => {
+    expect(choice('Diodes', 2).amount(set)).toBe(expected);
+  });
+});
+
+describe('Resistors', () => {
+  for (let i = 0; i < 2; i++) {
+    const c = choice('Resistors', i);
+    it.each`
+      set          | expected
+      ${SET.LOWER}| ${1}
+      ${SET.CORE} | ${1}
+      ${SET.ENHANCED}| ${1}
+      ${SET.FULL} | ${1}
+    `(`${c.name}: $expected pack for $set trackers`, ({ set, expected }) => {
+      expect(c.amount(set)).toBe(expected);
+    });
+  }
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${0}
+    ${SET.CORE} | ${0}
+    ${SET.ENHANCED}| ${0}
+    ${SET.FULL} | ${0}
+  `('Sourced elsewhere: $expected for $set trackers', ({ set, expected }) => {
+    expect(choice('Resistors', 2).amount(set)).toBe(expected);
+  });
+});
+
+describe('Carrier Board Options', () => {
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${10}
+    ${SET.CORE} | ${10}
+    ${SET.ENHANCED}| ${10}
+    ${SET.FULL} | ${10}
+  `('PCB from cases page: $expected PCBs for $set trackers', ({ set, expected }) => {
+    expect(choice('Carrier Board Options', 0).amount(set)).toBe(expected);
+  });
+
+  for (let i = 1; i <= 2; i++) {
+    const c = choice('Carrier Board Options', i);
+    it.each`
+      set          | expected
+      ${SET.LOWER}| ${1}
+      ${SET.CORE} | ${1}
+      ${SET.ENHANCED}| ${1}
+      ${SET.FULL} | ${1}
+    `(`${c.name}: $expected for $set trackers`, ({ set, expected }) => {
+      expect(c.amount(set)).toBe(expected);
+    });
+  }
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${0}
+    ${SET.CORE} | ${0}
+    ${SET.ENHANCED}| ${0}
+    ${SET.FULL} | ${0}
+  `('Sourced elsewhere: $expected for $set trackers', ({ set, expected }) => {
+    expect(choice('Carrier Board Options', 3).amount(set)).toBe(expected);
+  });
+});
+
+describe('Wiring for Extensions', () => {
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${0}
+    ${SET.CORE} | ${0}
+    ${SET.ENHANCED}| ${1}
+    ${SET.FULL} | ${1}
+  `('JST 5-pin 5 pcs: $expected packs for $set trackers', ({ set, expected }) => {
+    expect(choice('Wiring for Extensions', 0).amount(set)).toBe(expected);
+  });
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${0}
+    ${SET.CORE} | ${0}
+    ${SET.ENHANCED}| ${1}
+    ${SET.FULL} | ${1}
+  `('JST 5-pin 20 pcs: $expected packs for $set trackers', ({ set, expected }) => {
+    expect(choice('Wiring for Extensions', 1).amount(set)).toBe(expected);
+  });
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${0}
+    ${SET.CORE} | ${0}
+    ${SET.ENHANCED}| ${1}
+    ${SET.FULL} | ${1}
+  `('Deluxe Set: $expected packs for $set trackers', ({ set, expected }) => {
+    expect(choice('Wiring for Extensions', 2).amount(set)).toBe(expected);
+  });
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${0}
+    ${SET.CORE} | ${0}
+    ${SET.ENHANCED}| ${1}
+    ${SET.FULL} | ${1}
+  `('Full-Body Set: $expected packs for $set trackers', ({ set, expected }) => {
+    expect(choice('Wiring for Extensions', 3).amount(set)).toBe(expected);
+  });
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${0}
+    ${SET.CORE} | ${0}
+    ${SET.ENHANCED}| ${0}
+    ${SET.FULL} | ${0}
+  `('Sourced elsewhere: $expected for $set trackers', ({ set, expected }) => {
+    expect(choice('Wiring for Extensions', 4).amount(set)).toBe(expected);
+  });
+});
+
+describe('Cases', () => {
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${SET.LOWER}
+    ${SET.CORE} | ${SET.CORE}
+    ${SET.ENHANCED}| ${SET.ENHANCED}
+    ${SET.FULL} | ${SET.FULL}
+  `('3D printed: $expected cases for $set trackers', ({ set, expected }) => {
+    expect(choice('Cases', 0).amount(set)).toBe(expected);
+  });
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${1}
+    ${SET.CORE} | ${1}
+    ${SET.ENHANCED}| ${2}
+    ${SET.FULL} | ${2}
+  `('Amazon cases 6-pack: $expected packs for $set trackers', ({ set, expected }) => {
+    expect(choice('Cases', 1).amount(set)).toBe(expected);
+  });
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${0}
+    ${SET.CORE} | ${0}
+    ${SET.ENHANCED}| ${0}
+    ${SET.FULL} | ${0}
+  `('Sourced elsewhere: $expected for $set trackers', ({ set, expected }) => {
+    expect(choice('Cases', 2).amount(set)).toBe(expected);
+  });
+});
+
+describe('Straps', () => {
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${1}
+    ${SET.CORE} | ${2}
+    ${SET.ENHANCED}| ${2}
+    ${SET.FULL} | ${2}
+  `('AliExpress straps 6-pack: $expected packs for $set trackers', ({ set, expected }) => {
+    expect(choice('Straps', 0).amount(set)).toBe(expected);
+  });
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${2}
+    ${SET.CORE} | ${2}
+    ${SET.ENHANCED}| ${2}
+    ${SET.FULL} | ${2}
+  `('Amazon straps 5-pack: $expected packs for $set trackers', ({ set, expected }) => {
+    expect(choice('Straps', 1).amount(set)).toBe(expected);
+  });
+
+  it.each`
+    set          | expected
+    ${SET.LOWER}| ${0}
+    ${SET.CORE} | ${0}
+    ${SET.ENHANCED}| ${0}
+    ${SET.FULL} | ${0}
+  `('Sourced elsewhere: $expected for $set trackers', ({ set, expected }) => {
+    expect(choice('Straps', 2).amount(set)).toBe(expected);
+  });
+});

--- a/src/assets/js/diy-calculator/index.js
+++ b/src/assets/js/diy-calculator/index.js
@@ -1,0 +1,7 @@
+import { initializeCalculator } from './ui.js';
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeCalculator);
+} else {
+    initializeCalculator();
+}

--- a/src/assets/js/diy-calculator/ui.js
+++ b/src/assets/js/diy-calculator/ui.js
@@ -1,0 +1,133 @@
+import { makeElement, formatCost, getSelectedSet, getSelectedChoiceIndex } from "./utils.js";
+import { componentCategories, physicalTrackerCount } from "./components-data.js";
+
+export let trackerAmount = 6;
+
+function sanitizeComponentName(name) {
+    const stripped = name.replace(/<[^>]*>/g, '');
+    return stripped.replace(/[!"#$%&'()*+,.\/:;?@[\\\]^`{|}~\s]/g, '_');
+}
+
+export function updateComponentRow(component, set) {
+    let choice;
+    if (component.choices.length == 1) {
+        choice = component.choices[0];
+    } else {
+        const selectedIndex = getSelectedChoiceIndex(component.radioGroup);
+        choice = component.choices[selectedIndex];
+    }
+
+    component.amount.innerHTML = choice.amount(set) != 0 ? choice.amount(set) : "";
+    component.cost.innerHTML = choice.cost(set) != 0 ? formatCost(choice.cost(set)) : "";
+    component.costAll.innerHTML = choice.costAll(set) != 0 ? formatCost(choice.costAll(set)) : "";
+
+    component.links.innerHTML = choice.links;
+    return choice.costAll(set);
+}
+
+export const updatePrices = () => {
+    trackerAmount = getSelectedSet();
+    const set = trackerAmount;
+
+    let total = 0;
+    componentCategories.forEach((component) => {
+        if (component.hideFor5Set) {
+            component.tr.style.visibility = (set == 5 ? "hidden" : "visible");
+            if (set == 5) return;
+        }
+        total += updateComponentRow(component, set);
+    });
+
+    document.getElementById("diy-total-value").innerHTML = formatCost(total);
+};
+
+function createRadioCard(component, choiceObj, index) {
+    const card = document.createElement("div");
+    card.className = "radio-card";
+    card.tabIndex = 0;
+    card.style.cursor = "pointer";
+
+    const radio = document.createElement("input");
+    radio.type = "radio";
+    radio.name = component.radioName;
+    radio.value = index;
+    if (choiceObj.defaultSelected || index === 0) radio.checked = true;
+    radio.addEventListener("change", updatePrices);
+    component.radioGroup.push(radio);
+
+    card.addEventListener("click", () => {
+        radio.checked = true;
+        updatePrices();
+    });
+
+    card.addEventListener("keydown", (e) => {
+        if (e.key === " " || e.key === "Enter") {
+            radio.checked = true;
+            updatePrices();
+            e.preventDefault();
+        }
+    });
+
+    const info = document.createElement("div");
+    info.className = "radio-card-info";
+
+    const nameEl = document.createElement("div");
+    nameEl.className = "radio-card-name";
+    nameEl.innerHTML = choiceObj.name;
+    info.appendChild(nameEl);
+
+    if (choiceObj.description) {
+        const descEl = document.createElement("div");
+        descEl.className = "radio-card-desc";
+        descEl.innerHTML = choiceObj.description;
+        info.appendChild(descEl);
+    }
+
+    const costEl = document.createElement("div");
+    costEl.className = "radio-card-cost";
+    const cost = choiceObj.costAll(trackerAmount);
+    costEl.innerHTML = cost != 0 ? `~${formatCost(cost)}` : "";
+
+    card.appendChild(radio);
+    card.appendChild(info);
+    card.appendChild(costEl);
+
+    return card;
+}
+
+function createRadioGroup(component, choiceCell) {
+    component.radioGroup = [];
+    component.radioName = "name-" + sanitizeComponentName(component.name);
+    component.choices.forEach((choiceObj, index) => {
+        choiceCell.appendChild(createRadioCard(component, choiceObj, index));
+    });
+}
+
+function createComponentRow(component, tbody) {
+    const tr = makeElement(tbody, "tr");
+    component.tr = tr;
+    makeElement(tr, "th", component.name);
+
+    const choice = makeElement(tr, "td");
+    if (component.choices.length == 1) {
+        choice.innerHTML = component.choices[0].name;
+    } else {
+        const group = document.createElement("div");
+        group.className = "radio-card-group";
+        choice.appendChild(group);
+        createRadioGroup(component, group);
+    }
+
+    component.amount = makeElement(tr, "td");
+    component.cost = makeElement(tr, "td");
+    component.costAll = makeElement(tr, "td");
+    component.links = makeElement(tr, "td");
+}
+
+export function initializeCalculator() {
+    const tbody = document.getElementById("diy-components");
+    componentCategories.forEach((component) => createComponentRow(component, tbody));
+
+    updatePrices();
+    document.querySelectorAll('input[name="diy-set"]').forEach((set) => set.addEventListener("change", updatePrices));
+}

--- a/src/assets/js/diy-calculator/utils.js
+++ b/src/assets/js/diy-calculator/utils.js
@@ -1,0 +1,19 @@
+export const makeElement = (parent, type, contents = "") => {
+    const el = document.createElement(type);
+    el.innerHTML = contents;
+    parent.appendChild(el);
+    return el;
+};
+
+export function formatCost(value) {
+    return "$" + value.toFixed(2).replace(/\.00$/, "");
+}
+
+export function getSelectedSet() {
+    return +document.querySelector("input[name=diy-set]:checked").value;
+}
+
+export function getSelectedChoiceIndex(radioGroup) {
+    const checkedRadio = radioGroup.find((radio) => radio.checked);
+    return checkedRadio ? checkedRadio.value : 0;
+}

--- a/src/assets/js/diy.js
+++ b/src/assets/js/diy.js
@@ -19,77 +19,77 @@
             'choices': [
                 //Prices are based on the seller "Simple Robot Store" for AliExpress links.
                 {
-                    'name': 'ICM-45686',
+                    'name': '🟢 ICM-45686',
                     'amount': (set) => set,
                     'cost': 6.70,
                     'costAll': (set) => set * 6.70 + 6.70,
                     'links': '<a href="https://shop.slimevr.dev/products/slimevr-mumo-breakout-module-v1-icm-45686-qmc6309">SlimeVR Mumo Breakout Module V1 (ICM-45686 + QMC6309)</a>.'
                 },
                 {
-                    'name': 'LSM6DSV',
+                    'name': '🟢 LSM6DSV',
                     'amount': (set) => set,
                     'cost': 8.47,
                     'costAll': (set) => set * 8.47 + 5.58,
                     'links': '<a href="https://moffshop.deyta.de/products/lsm6dsv-module" target="_blank">Moffshop LSM6DSV</a>.'
                 },
                 {
-                    'name': 'LSM6DSR',
+                    'name': '🟢 LSM6DSR',
                     'amount': (set) => set,
                     'cost': 3.15,
                     'costAll': (set) => set * 3.35 + 6.70,
-                    'links': '<a href="https://moffshop.deyta.de/products/lsm6dsr">Moffshop LSM6DSR + QMC6309</a>, <b>experimental</b>.'
+                    'links': '<a href="https://www.aliexpress.com/wholesale?SearchText=LSM6DSR">AliExpress LSM6DSR</a>, <b>experimental</b>.'
                 },
                 {
-                    'name': 'BNO085',
+                    'name': '🔴 BNO085',
                     'amount': (set) => set,
                     'cost': 11,
                     'costAll': (set) => set * 11 + 6,
                     'links': '<a href="https://www.mouser.com/c/?q=BNO085" target="_blank">Adafruit BNO085</a>, <b>Not recommended for new designs.</b>'
                 },
                 {
-                    'name': 'BMI160',
+                    'name': '🚫 BMI160',
                     'amount': (set) => set,
                     'cost': 1.42,
                     'costAll': (set) => set * 1.42 + 2.67,
                     'links': '<a href="https://www.aliexpress.com/wholesale?SearchText=BMI160">AliExpress BMI160</a>, <b>Not recommended for new designs.</b>'
                 },
                 {
-                    'name': 'ICM20948',
+                    'name': '🔴 ICM20948',
                     'amount': (set) => set,
                     'cost': 17.40,
                     'costAll': (set) => set * 17.40 + 8.89,
                     'links': '<a href="https://www.mouser.com/c/?q=ICM20948">Mouser ICM20948</a>. The most commonly chosen options are either the Pimoroni or Adafruit ICM20948. Please note that any orders you place will be <b>backordered</b>, potentially meaning a wait of <u>upwards of 3 months</u> before shipping. <b>Not recommended for new designs.</b>'
                 },
                 {
-                    'name': 'MPU9250',
+                    'name': '🚫 MPU9250',
                     'amount': (set) => set,
                     'cost': 4.75,
                     'costAll': (set) => set * 4.75 + 2.73,
                     'links': '<a href="https://www.aliexpress.com/wholesale?SearchText=MPU9250">AliExpress MPU9250</a>. Buyer beware: large amount of fakes. <b>Not recommended for new designs.</b>'
                 },
                 {
-                    'name': 'MPU+QMC5883L',
+                    'name': '🚫 MPU+QMC5883L',
                     'amount': (set) => set,
                     'cost': 1.04+1.23,
                     'costAll': (set) => (set * (1.04+1.23)) + 2.67,
                     'links': '<a href="https://www.aliexpress.com/wholesale?SearchText=MPU6050">AliExpress MPU6050</a> and <a href="https://www.aliexpress.com/wholesale?SearchText=QMC5883L">AliExpress QMC5883L</a>. Performance should apprxomiately match an MPU9250, but please note that this is <b>Experimental</b>. <b>Not recommended for new designs.</b>'
                 },
                 {
-                    'name': 'BNO055',
+                    'name': '🔴 BNO055',
                     'amount': (set) => set,
                     'cost': 17,
                     'costAll': (set) => set * 17 + 2.73,
                     'links': '<a href="https://www.aliexpress.com/wholesale?SearchText=BNO055">AliExpress BNO055</a>. <b>Not recommended for new designs.</b>'
                 },
                 {
-                    'name': 'MPU6500',
+                    'name': '🚫 MPU6500',
                     'amount': (set) => set,
                     'cost': 0.95,
                     'costAll': (set) => set * 0.95 + 2.67,
                     'links': '<a href="https://www.aliexpress.com/wholesale?SearchText=MPU6500">AliExpress MPU6500</a>. <b>Not recommended for new designs.</b>'
                 },
                 {
-                    'name': 'MPU6050',
+                    'name': '🚫 MPU6050',
                     'amount': (set) => set,
                     'cost': 1.04,
                     'costAll': (set) => set * 1.04 + 2.67,
@@ -105,7 +105,7 @@
                     'amount': () => tracker,
                     'cost': 3.66,
                     'costAll': () => tracker*3.19 + 5.33,
-                    'links': '<a href="https://www.aliexpress.us/item/3256803961495200.html">AliExpress 804040, 5 pcs</a> or <a href="https://www.aliexpress.com/item/1005002559604104.html">AliExpress 804040, 10 pcs</a>. Pricing is approximate.'
+                    'links': '<a href="https://www.aliexpress.us/item/3256803961495200.html">AliExpress 🚫 unavailable</a> or <a href="https://www.aliexpress.com/item/1005002559604104.html">AliExpress 🚫 unavailable</a>.'
                 },
                 {
                     'name': '1200 mAh 903052 Li-Po - 5 pcs',
@@ -119,7 +119,7 @@
                     'amount': () => tracker,
                     'cost': 3 + 0.27,
                     'costAll': () => tracker * (3 + 0.27) + (1.89),
-                    'links': '<a href="https://www.aliexpress.com/wholesale?SearchText=18650+cell">AliExpress 18650 cell</a> and <a href="https://www.aliexpress.us/item/3256801521575042.html">AliExpress 18650 holder</a>. Buyer beware: rated capacities are likely inaccurate.'
+                    'links': '<a href="https://www.aliexpress.com/wholesale?SearchText=18650+cell">AliExpress 18650 cell</a> and <a href="https://www.aliexpress.us/item/3256801521575042.html">AliExpress (X4 Slot)</a>. Buyer beware: rated capacities are likely inaccurate.'
                 },
                 {
                     'name': 'Sourced elsewhere',
@@ -138,7 +138,7 @@
                     'amount': () => tracker,
                     'cost': 0.36,
                     'costAll': () => tracker*0.36 + 2.07,
-                    'links': '<a href="https://www.aliexpress.com/item/32649780468.html">AliExpress TP4056</a>'
+                    'links': '<a href="https://www.aliexpress.com/item/32649780468.html">AliExpress (18650 mini / type-c / micro)</a>'
                 },
                 {
                     'name': 'TP4056 USB charging board - 10 pcs',
@@ -162,9 +162,9 @@
                 {
                     'name': 'SS22F32 switches - 10 pcs',
                     'amount': () => 1,
-                    'cost': 2.36,
-                    'costAll': () => 2.36,
-                    'links': '<a href="https://www.aliexpress.com/item/32975535599.html">AliExpress SS22F32 switches</a>'
+                    'cost': 1.97,
+                    'costAll': () => 1.97,
+                    'links': '<a href="https://www.aliexpress.com/item/32975535599.html">AliExpress</a>'
                 },
                 {
                     'name': 'SS22F32 switches - 10 pcs (Alt)',
@@ -197,7 +197,7 @@
                     'amount': () => 1,
                     'cost': 0.62,
                     'costAll': () => 0.62 + 2.21,
-                    'links': '<a href="https://www.aliexpress.us/item/3256801365779334.html">AliExpress 1N5817 diodes.</a> Optional component for battery protection.'
+                    'links': '<a href="https://www.aliexpress.us/item/3256801365779334.html">AliExpress (1N5817)</a>. Optional component for battery protection.'
                 },
                 {
                     'name': '1N5817 diodes - 100 pcs',
@@ -223,7 +223,7 @@
                     'amount': () => 1,
                     'cost': 1.96,
                     'costAll': () => 1.96 + 1.29,
-                    'links': '<a href="https://www.aliexpress.us/item/3256802808441054.html">AliExpress 180K ohm resistors.</a> Optional component for checking battery percentage.'
+                    'links': '<a href="https://www.aliexpress.us/item/3256802808441054.html">AliExpress (100pcs 180K ohms)</a>. Optional component for checking battery percentage.'
                 },
                 {
                     'name': '180K ohm resistors - 100 pcs (Alt)',
@@ -256,7 +256,7 @@
                     'amount': () => 1,
                     'cost': 1.85,
                     'costAll': () => 1.85+1.68,
-                    'links': '<a href="https://www.aliexpress.com/item/1005002632016529.html">AliExpress 24-26 AWG 5m</a>'
+                    'links': '<a href="https://www.aliexpress.com/item/1005002632016529.html">AliExpress (22 AWG, 2m)</a>'
                 },
                 {
                     'name': '26AWG Wire, No PCB (Not Recommended)',
@@ -316,7 +316,7 @@
                     'amount': () => tracker,
                     'cost': 0.65,
                     'costAll': () => (tracker * 0.65) + 3.01,
-                    'links': '<a href="https://www.aliexpress.us/item/3256803305182027.html">AliExpress cases</a>. Not guaranteed to fit, check your parts before ordering.'
+                    'links': '<a href="https://www.aliexpress.us/item/3256803305182027.html">AliExpress 🚫 unavailable</a>.'
                 },
                 {
                     'name': 'Amazon cases - 6 pcs',
@@ -338,14 +338,14 @@
                     'links': ''
                 },
                 {
-                    'name': 'Generic AliExpress straps - 6 pcs',
+                    'name': '🟡 Generic AliExpress straps - 6 pcs',
                     'amount': (set) => ((set < 6) ? 1 : 2),
                     'cost': 5,
                     'costAll': (set) => ((set < 6) ? 1 : 2) * 5 + 2.77,
                     'links': '<a href="https://aliexpress.com/item/1005001908740631.html">AliExpress straps</a>, get some in different sizes?'
                 },
                 {
-                    'name': 'Generic Amazon straps - 5 pcs',
+                    'name': '🟡 Generic Amazon straps - 5 pcs',
                     'amount': (set) => ((set < 5) ? 1 : 2),
                     'cost': 9.00,
                     'costAll': (set) => ((set < 5) ? 1 : 2) * 9.00,

--- a/src/diy/components-guide.md
+++ b/src/diy/components-guide.md
@@ -1,6 +1,16 @@
 # Components Guide
 
-The costs shown should be taken as a **rough approximation** due to prices changing over time. Prices are in USD.
+
+```admonish info
+- The costs shown should be taken as a **rough approximation** due to prices changing over time. Prices are in USD.
+- Prices last updated: 2026-06-05.
+- Links sourced by community.
+```
+
+## Table Of Contents
+
+- TOC
+  {:toc}
 
 ## Don't order yet!
 This guide is meant to show rough price estimates for the components needed to build a set of SlimeVR trackers.
@@ -15,23 +25,64 @@ This limitation is due to the processing load required for handling multiple IMU
 Official SlimeVR Tracker v1.2 hardware uses an SPI interface to overcome this limitation.
 ```
 
-**Number of trackers**
+### Select Number of Trackers
 
-<input id="5imu" type="radio" name="diy-set" value="5"> <label for="5imu">Lower-Body Set - 5 Trackers</label>&nbsp; &nbsp;|&nbsp;
-<input id="6imu" type="radio" name="diy-set" value="6" checked="checked"> <label for="6imu">Core Set - 6 Trackers</label>&nbsp; &nbsp;|&nbsp;
-<input id="8imu" type="radio" name="diy-set" value="8"> <label for="8imu">Enhanced Core Set - 6 Trackers, 2 Extensions</label>&nbsp; &nbsp;|&nbsp;
-<input id="10imu" type="radio" name="diy-set" value="10"> <label for="10imu">Full-Body Set - 8 Trackers, 2 Extensions</label>
+Before you start, decide on [how many trackers you may need](../../../slimevr101.md#how-many-trackers-do-you-need).
 
----
+<div class="radio-card-group">
+  <div class="radio-card">
+    <input type="radio" name="diy-set" value="5" id="trackers-5" />
+    <label for="trackers-5">
+      <div class="radio-card-name">🟡 Lower-Body Set</div>
+      <div class="radio-card-desc">5 Trackers &mdash; Casual VR users</div>
+      <div class="radio-card-desc">
+        Provides positional tracking for legs and spine. Limited tracking for foot orientation and lower spine bending.
+      </div>
+    </label>
+  </div>
+  <div class="radio-card">
+    <input type="radio" name="diy-set" value="6" id="trackers-6" checked="checked" />
+    <label for="trackers-6">
+      <div class="radio-card-name">🟢 Core Set</div>
+      <div class="radio-card-desc">6 Trackers &mdash; Users who want better stability</div>
+      <div class="radio-card-desc">
+        Adds an extra spine tracker for improved stability, especially when sitting, lying down, or bending over.
+      </div>
+    </label>
+  </div>
+  <div class="radio-card">
+    <input type="radio" name="diy-set" value="8" id="trackers-8" />
+    <label for="trackers-8">
+      <div class="radio-card-name">🟢 Enhanced Core Set</div>
+      <div class="radio-card-desc">6 Trackers, 2 Extensions &mdash; Users who sit or lie down often</div>
+      <div class="radio-card-desc">
+        Adds foot movement tracking for more expressive, emotive poses when seated or lying down.
+      </div>
+    </label>
+  </div>
+  <div class="radio-card">
+    <input type="radio" name="diy-set" value="10" id="trackers-10" />
+    <label for="trackers-10">
+      <div class="radio-card-name">🟢 Full-Body Set</div>
+      <div class="radio-card-desc">8 Trackers, 2 Extensions &mdash; Dancers, role-players, immersive users</div>
+      <div class="radio-card-desc">
+        Enables independent elbow movement, providing more realistic upper-body motion and increased immersion in VR.
+      </div>
+    </label>
+  </div>
+</div>
+
+### Select Parts
+
 <div class="table-wrapper">
     <table>
         <thead>
             <tr>
                 <th>Component</th>
-                <th>Choice</th>
+                <th style="width:70%">Choice</th>
                 <th>Amount</th>
-                <th>Cost per</th>
-                <th>Cost with Shipping</th>
+                <th>Cost per one</th>
+                <th>Cost Total</th>
                 <th style="min-width: 200px">Quick Link</th>
             </tr>
         </thead>
@@ -40,7 +91,10 @@ Official SlimeVR Tracker v1.2 hardware uses an SPI interface to overcome this li
     </table>
 </div>
 
-**TOTAL COST**: ~$<span id="diy-total"></span>
+<div class="total-cost">
+  <strong>TOTAL COST:</strong>
+  ~<span id="diy-total-value"></span>
+</div>
 
 **Please note**: JST connectors are an optional convenience if you want to be able to disconnect your extensions. If you plan on never disconnecting your extensions, you do not need JST connectors. Instead, hardwiring the extensions is recommended for durability.
 
@@ -53,10 +107,6 @@ The most impactful choice regarding DIY SlimeVR trackers is the IMU (Inertial Me
 The second most impactful choice will be where you choose to purchase your components. This guide uses components sourced from AliExpress, due to price and availability. However, shipping times from AliExpress are long compared to other options—often 3-6 weeks—and have a chance to be faulty on arrival. Components may also be purchased from Amazon or local retailers, although pricing and availability will vary wildly.
 
 While purchasing components, especially from AliExpress, it is also highly recommended to purchase one or two extra of each part in case they come dead on arrival or due to soldering mistakes. Keep in mind that AliExpress shipping times are quite long, which means replacements for faulty components may have a very long wait time—so plan accordingly. Generally speaking, IMUs generally have the highest DOA (dead-on-arrival) rate. Wemos D1 Minis, TP4046 charging boards, and batteries are all fairly reliable with low DOA rates—however it still may be worthwhile purchasing extras just in case.
-
-* TOC
-{:toc}
-
 
 ### Tools
 
@@ -153,16 +203,90 @@ Some parts are known to arrive DOA — including 1-2 spares in your order is rec
 - IMU (Most notably MPU, BMI160)
 
 *Created by Carl (<https://github.com/carl-anders>), edited by calliepepper, nwbx01, Smeltie, and Amebun*
-<script src="../assets/js/diy.js"></script>
+<script type="module" src="../assets/js/diy-calculator/index.js"></script>
 <style>
-    @media (min-width: 50rem) {
-        .main { max-width: 1100px !important; }
+table thead th,
+table tbody td {
+    padding: 3px 10px;
+}
+
+fieldset {
+    border-radius: 8px;
+}
+
+.total-cost {
+    padding-top: 10px;
+    font-size: large;
+}
+
+.radio-card-group {
+    padding-top: 10px;
+    padding-bottom: 10px;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 10px;
+}
+
+@media (min-width: 50rem) {
+    .main {
+        max-width: 1100px !important;
     }
-    select {
-        width:250px;
-    }
-    td:first-of-type {
+}
+
+select {
+    width: 100%;
+    padding: 10px;
+    font-size: 16px;
+    border-radius: 5px;
+}
+
+td:first-of-type {
     border-left: 1px solid #eeebee;
-    }
+}
+
+:root {
+  --content-max-width: 2000px;
+}
+
+td label {
+  padding-bottom: 10px;
+}
+
+.radio-card-group {
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+
+.radio-card {
+    border: 1px solid var(--theme-popup-border);
+    border-radius: 6px;
+    padding: 8px;
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.radio-card:has(input[type="radio"]:checked) {
+    outline: 2px solid var(--sidebar-active);
+    outline-offset: 2px;
+}
+
+.radio-card-info {
+    flex: 1;
+}
+
+.radio-card-name {
+    font-weight: bold;
+}
+
+.radio-card-desc {
+    font-size: 0.95em;
+}
+
+.radio-card-cost {
+    font-weight: bold;
+    margin-left: 16px;
+}
 </style>
 


### PR DESCRIPTION
- Replace inline script with ES module calculator (components-data, ui, utils, index)
- Add primaryTrackerCount/extensionCount helpers for 5/6/8/10 set logic
- Introduce new component categories: Carrier Board Options, Wiring for Extensions
- Update pricing across all components (MCU, IMU, batteries, charging, straps, etc.)
- Add VYRO VR Silicone Straps and Comfort Strap Bundle to DIY calculator
- Restructure components-guide.md with radio card UI, TOC, styled tables
- Update diy.js with emoji-labeled IMU options and fresh links/pricing