### PR TITLE
Remove 2.1V firmware for smols. Updated references to outdated firmware versions in smol flashing and compiling firmware

### DIFF
--- a/src/smol-slimes/firmware/smol-compiling-firmware.md
+++ b/src/smol-slimes/firmware/smol-compiling-firmware.md
@@ -236,9 +236,40 @@ Please open a GitHub issue for any firmware bugs or issues in the corresponding 
 **Resource:** <a href="https://github.com/joric/nrfmicro/wiki/Bootloader">https://github.com/joric/nrfmicro/wiki/Bootloader</a>
 
 #### J-Link, nRF52/nRF52840 Development Kit, and OB-ARM Debugger
-1. Install J-Link Software and Documentation Pack: <a href="https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack">https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack</a>
-1. Download Bootloader HEX File for your device (ProMicro - <a href="https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/slimenrf_promicro_bootloader-0.9.2-SlimeVR.7_s140_7.3.0.hex" target="_blank">slimenrf_promicro_bootloader-0.9.2-SlimeVR.7_s140_7.3.0.hex</a>, XIAO - <a href="https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/slimenrf_xiao_sense_bootloader-0.9.2-SlimeVR.7_s140_7.3.0.hex" target="_blank">slimenrf_xiao_sense_bootloader-0.9.2-SlimeVR.7_s140_7.3.0.hex</a>)
-1. Connect Debugger to SWD IO, CLK, and GND Pins. (It is safer to power up your device by plugging into USB instead of using the VDD pin)
+
+1. Install J-Link Software and Documentation Pack: 
+    <a href="https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack">https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack</a>
+2. Download Bootloader HEX File for your device 
+<div class="table-wrapper">
+  <table>
+    <thead>
+      <tr>
+        <th>Device</th>
+        <th>HEX</th>
+      </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>ProMicro</td>
+      <td>
+        <a href="https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.11.0/nice_nano_bootloader-0.11.0_s140_6.1.1.hex">
+          Link
+          </a>
+      </td>
+    </tr>
+    <tr>
+      <td>XIAO</td>
+      <td>
+        <a href="https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.11.0/xiao_nrf52840_ble_sense_bootloader-0.11.0_s140_7.3.0.hex">
+          Link
+          </a>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+
+3. Connect Debugger to SWD IO, CLK, and GND Pins. (It is safer to power up your device by plugging into USB instead of using the VDD pin)
 
 ##### Flashing/Fixing bricked bootloader
 1. Launch "J-Flash Lite."

--- a/src/smol-slimes/firmware/smol-flashing-firmware.md
+++ b/src/smol-slimes/firmware/smol-flashing-firmware.md
@@ -8,16 +8,51 @@
 ## Flashing Boards with Adafruits UF2 Bootloader (ProMicro / XIAO)
 
 ### Flashing the Bootloader
-1. For the ProMicro, download <a href="https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/update-slimenrf_promicro_bootloader-0.9.2-SlimeVR.7_nosd.uf2" target="_blank">update-slimenrf_promicro_bootloader-0.9.2-SlimeVR.7_nosd.uf2</a>. For the XIAO, download <a href="https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/update-slimenrf_xiao_sense_bootloader-0.9.2-SlimeVR.7_nosd.uf2" target="_blank">update-slimenrf_xiao_sense_bootloader-0.9.2-SlimeVR.7_nosd.uf2</a>.
-1. Connect the device to your computer using a USB data cable.
-1. The device should initially start in DFU mode when new and without a bootloader. The LED should fade on and off.
-1. If the device's LED is not fading on and off, press the reset button twice (or briefly short the RST and GND pins) twice within 0.5 seconds. If the device has existing SlimeNRF firmware, reset it four times.
-1. Navigate to your Downloads folder and copy the UF2 file.
-1. Navigate to the Mass Storage Drive (ex. NICENANO/XIAO-SENSE) from ThisPC.
-1. Paste the file there, and the window should close, causing the device to reboot.
+1. Download firmware.
+<div class="table-wrapper">
+  <table>
+    <thead>
+      <tr>
+        <th>Device</th>
+        <th>UF2</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>ProMicro</td>
+        <td>
+          <a href="https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.11.0/update-nice_nano_bootloader-0.11.0_nosd.uf2">
+            Link
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td>XIAO</td>
+        <td>
+          <a
+            href="https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.11.0/update-xiao_nrf52840_ble_sense_bootloader-0.11.0_nosd.uf2"
+          >
+            Link
+          </a>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+2. Connect the device to your computer using a USB data cable.
+3. The device should initially start in DFU mode when new and without a bootloader.
+  The LED should fade on and off.
+4. If the device's LED is not fading on and off, press the reset button twice (or briefly short the RST and GND pins) twice within 0.5 seconds.
+  If the device has existing SlimeNRF firmware, reset it four times.
+5. Navigate to your Downloads folder and copy the UF2 file.
+6. Navigate to the Mass Storage Drive (ex. NICENANO/XIAO-SENSE) from ThisPC.
+7. Paste the file there, and the window should close, causing the device to reboot.
 
 ```admonish important
-Update the bootloader on your ProMicro and XIAO boards before flashing the firmware; otherwise, there is a significant risk of bricking your device. eByte and Nordic dongles are not included in this category.
+Update the bootloader on your ProMicro and XIAO boards before flashing the firmware; otherwise, there is a significant risk of bricking your device.
+
+eByte and Nordic dongles are not included in this category.
 ```
 
 ### Flashing the Firmware using UF2

--- a/src/smol-slimes/firmware/smol-pre-compiled-firmware.md
+++ b/src/smol-slimes/firmware/smol-pre-compiled-firmware.md
@@ -14,38 +14,58 @@ This is the recommended method of getting the firmware if you don't need custom 
 ## Required Tools
 
 You only need the following if you are using precompiled firmware:
-* <a href="https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-Desktop">nRF Connect for Desktop</a> (Programmer) for flashing Nordic or eByte Dongles only
-* <a href="https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-Desktop">nRF Connect for Desktop</a> (Serial Terminal) for sending commands to your Receiver/Trackers, [see alternatives](smol-pairing-and-calibration.md#required-tools)
-* Or [SmolSlimeConfigurator](SmolSlimeConfigurator.md), an all-in-one programming and configuration tool for your Smol Slimes.
-* <a href="https://slimevr.dev/download">SlimeVR Server</a>
-    * 0.13.2 or later version
 
-
-## Recommended Bootloader
-
-```admonish warning
-On ProMicro boards, 2.1V bootloader is generally recommended because it is more power efficient.
-
-However, some components (such as the QMC6309 magnetometer) may not operate correctly at this voltage, in which case you must use the 3.3V bootloader instead.
-
-### Important compatibility notes
-
-- You **can re-flash from 3.3V → 2.1V** using the UF2 bootloader.
-- You **cannot re-flash from 2.1V → 3.3V** using UF2 alone.
-  - This requires an **SWD debugger** (see: [SWD debugging](./smol-compiling-firmware.html#swd-debugging)).
-```
+- <a href="https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-Desktop">nRF Connect for Desktop</a> (Programmer) for flashing Nordic or eByte Dongles only
+- <a href="https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-Desktop">nRF Connect for Desktop</a> (Serial Terminal) for sending commands to your Receiver/Trackers, [see alternatives](smol-pairing-and-calibration.md#required-tools)
+- Or [SmolSlimeConfigurator](SmolSlimeConfigurator.md), an all-in-one programming and configuration tool for your Smol Slimes.
+- <a href="https://slimevr.dev/download">SlimeVR Server</a>
+    - 0.13.2 or later version
 
 #### 💿 Bootloader
 
-| Device | 2.1V UF2 | 2.1V HEX | 3.3V UF2 | 3.3V HEX |
-|--------|----------|----------|----------|----------|
-| ProMicro | [Link](https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/update-slimenrf_promicro_bootloader-0.9.2-SlimeVR.7_nosd.uf2) | [Link](https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/slimenrf_promicro_bootloader-0.9.2-SlimeVR.7_s140_7.3.0.hex) | [Link](https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.11.0/update-nice_nano_bootloader-0.11.0_nosd.uf2) | [Link](https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.11.0/nice_nano_bootloader-0.11.0_s140_6.1.1.hex) |
-| XIAO | [Link](https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/update-slimenrf_xiao_sense_bootloader-0.9.2-SlimeVR.7_nosd.uf2) | [Link](https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/slimenrf_xiao_sense_bootloader-0.9.2-SlimeVR.7_s140_7.3.0.hex) | [Link](https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.11.0/update-xiao_nrf52840_ble_sense_bootloader-0.11.0_nosd.uf2) | [Link](https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.11.0/xiao_nrf52840_ble_sense_bootloader-0.11.0_s140_7.3.0.hex) |
-| R3 | [Link](https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/update-slimenrf_tracker_r3_bootloader-0.9.2-SlimeVR.7_nosd.uf2) | [Link](https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/slimenrf_tracker_r3_bootloader-0.9.2-SlimeVR.7_s140_7.3.0.hex) | — | — |
-| Butterfly P1 | [Link](https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/update-slimevr_mini_p1_bootloader-0.9.2-SlimeVR.7_nosd.uf2) | [Link](https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/slimevr_mini_p1_bootloader-0.9.2-SlimeVR.7_s140_7.3.0.hex) | — | — |
-| Butterfly P2 | [Link](https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/update-slimevr_mini_p2_bootloader-0.9.2-SlimeVR.7_nosd.uf2) | [Link](https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/slimevr_mini_p2_bootloader-0.9.2-SlimeVR.7_s140_7.3.0.hex) | — | — |
-| Butterfly P3, R6 | [Link](https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/update-slimevr_mini_p3r6_bootloader-0.9.2-SlimeVR.7_nosd.uf2) | [Link](https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/slimevr_mini_p3r6_bootloader-0.9.2-SlimeVR.7_s140_7.3.0.hex) | — | — |
-| Butterfly P3, R7 | [Link](https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/update-slimevr_mini_p3r7_bootloader-0.9.2-SlimeVR.7_nosd.uf2) | [Link](https://github.com/SlimeVR/Adafruit_nRF52_Bootloader/releases/download/0.9.2-SlimeVR.7/slimevr_mini_p3r7_bootloader-0.9.2-SlimeVR.7_s140_7.3.0.hex) | — | — |
+**Difference between UF2 and HEX:**
+- UF2 - USB flashing format
+- HEX - nRF Connect Programmer format. Handy if UF2 option not works
+
+<div class="table-wrapper">
+  <table>
+    <thead>
+      <tr>
+        <th>Device</th>
+        <th>UF2</th>
+        <th>HEX</th>
+      </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>ProMicro</td>
+      <td>
+        <a href="https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.11.0/update-nice_nano_bootloader-0.11.0_nosd.uf2">
+          Link
+          </a> <sup style="font-size:0.6em">✅ recommended</sup>
+      </td>
+      <td>
+        <a href="https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.11.0/nice_nano_bootloader-0.11.0_s140_6.1.1.hex">
+          Link
+          </a>
+      </td>
+    </tr>
+    <tr>
+      <td>XIAO</td>
+      <td>
+        <a href="https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.11.0/update-xiao_nrf52840_ble_sense_bootloader-0.11.0_nosd.uf2">
+          Link
+          </a> <sup style="font-size:0.6em">✅ recommended</sup>
+      </td>
+      <td>
+        <a href="https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.11.0/xiao_nrf52840_ble_sense_bootloader-0.11.0_s140_7.3.0.hex">
+          Link
+          </a>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+</div>
 
 ## Latest Builds Firmware (Automated)
 
@@ -55,7 +75,7 @@ However, some components (such as the QMC6309 magnetometer) may not operate corr
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
 | Nordic/eByte | [Link](https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Nordic_eByte_Dongle_Receiver.hex) |
 | Holyiot      | [Link](https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_Holyiot_Dongle_Receiver.hex)      |
-| ProMicro     | [Link](https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_ProMicro_Receiver.uf2)           |
+| ProMicro     | [Link](https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_ProMicro_Receiver.uf2)            |
 | XIAO         | [Link](https://github.com/Shine-Bright-Meow/SlimeNRF-Firmware-CI/releases/download/latest/SlimeNRF_XIAO_Receiver.uf2)                |
 
 ### 🏃 Tracker
@@ -562,4 +582,4 @@ Previous builds can be found here: <a href="https://github.com/Shine-Bright-Meow
 
 ---
 
-*Created by Shine Bright ✨, [Depact](https://github.com/Depact) and [Seneral](https://github.com/Seneral)*
+_Created by Shine Bright ✨, [Depact](https://github.com/Depact) and [Seneral](https://github.com/Seneral)_


### PR DESCRIPTION

<img width="756" height="305" alt="{A5781956-2C9E-4350-A0F0-68D60F3B8D51}" src="https://github.com/user-attachments/assets/2d9f064d-50c2-403e-aa7d-93f6017d86b7" />

<img width="873" height="570" alt="{7036FBFD-1774-4F95-ABFA-BC8AC6A06EE1}" src="https://github.com/user-attachments/assets/8406df93-de90-4325-8db6-23e8d7ecb073" />

<img width="937" height="394" alt="{480C0DE5-99CD-4768-B3BC-02DE13D1A47A}" src="https://github.com/user-attachments/assets/4d68a2f1-2a18-4086-83e5-33d5672819fc" />

